### PR TITLE
Add writing-foundations route and map files for nonfiction-writing and storytelling

### DIFF
--- a/routes/nonfiction-writing/guide.md
+++ b/routes/nonfiction-writing/guide.md
@@ -1,0 +1,628 @@
+---
+title: Nonfiction Writing
+route_map: /routes/nonfiction-writing/map.md
+paired_sherpa: /routes/nonfiction-writing/sherpa.md
+prerequisites:
+  - Experience writing in English
+topics:
+  - Nonfiction Craft
+  - Leads
+  - Structure
+  - Clarity
+  - Voice
+  - Revision
+---
+
+# Nonfiction Writing
+
+> **Note for AI assistants**: This guide has a paired sherpa at `/routes/nonfiction-writing/sherpa.md` that provides structured teaching guidance.
+> **Route map**: See `/routes/nonfiction-writing/map.md` for the high-level overview.
+
+## Overview
+
+You have ideas worth sharing — about technology, culture, how things work, how they should work. But sitting down to actually write them out feels like a different skill entirely. This route teaches you the craft of nonfiction: how to take a raw idea and turn it into something someone else can follow, learn from, and act on.
+
+## Learning Objectives
+
+By the end of this route, you will be able to:
+- Take a raw idea and determine what kind of nonfiction piece it wants to be
+- Build a structural plan before drafting
+- Write leads that create genuine forward momentum
+- Explain complex ideas clearly using concrete examples and progressive disclosure
+- Edit your own work for clarity, concision, and logical flow
+- Identify and eliminate clutter, jargon, and hedging in your prose
+
+## Prerequisites
+
+Before starting, you should have:
+- Experience writing in English (emails, blog posts, reports — anything)
+
+It helps to have:
+- Completed the [Writing Foundations](/routes/writing-foundations/map.md) route
+- An idea you want to develop into a nonfiction piece
+
+## What You'll Need
+
+No software setup required. You'll need:
+- A text editor or word processor
+- An idea to develop (you'll build on it throughout the route)
+- Optionally: William Zinsser's *On Writing Well* — the single best book on nonfiction craft
+
+---
+
+## Section 1: What Makes Nonfiction Work
+
+### The Reader's Transaction
+
+Good nonfiction is a transaction. You have something to say; the reader gives you their time. In return, they expect clarity, substance, and a reason to keep going. Every sentence either earns the reader's continued attention or loses it.
+
+The reader's implicit question, from the first sentence to the last, is: **"Why should I keep reading?"**
+
+This is different from writing for yourself. A journal entry can wander, repeat, contradict itself — that's fine, because you're the only audience. But the moment you write for someone else, you owe them something: a clear purpose, a logical path, and a payoff at the end.
+
+### The What → Why → How Framework
+
+The simplest skeleton for any nonfiction piece has three parts:
+
+- **What**: State clearly what you're going to cover and what the reader will get from it
+- **Why**: Make the case for why this matters — give the reader stakes
+- **How**: Deliver the substance — details, steps, evidence, examples
+
+This isn't the only structure (we'll cover more in Section 3), but it's a reliable starting point. Most bad nonfiction fails because it skips one of these three — usually the Why. The writer assumes the reader already cares. They don't. You have to make them care.
+
+### How the Best Writers Do It
+
+Writers like Michael Lewis, Malcolm Gladwell, and John McPhee don't just present facts. They draw readers into factual material through **narrative and specificity**. Lewis opens *The Big Short* not with an explanation of mortgage-backed securities, but with a person — Steve Eisman — and a scene. Gladwell opens *The Tipping Point* with a specific neighborhood in New York and a specific year. McPhee opens *Oranges* by walking through a grove.
+
+The pattern: start specific and concrete, then zoom out to the larger idea. Specificity creates trust. Abstraction loses readers.
+
+### Key Points to Remember
+
+- **Nonfiction is a transaction.** The reader gives time; you owe clarity and substance.
+- **"Why should I keep reading?" is always the question.** Answer it early and keep answering it.
+- **What → Why → How** is the simplest reliable skeleton.
+- **Specificity pulls readers in.** Abstraction pushes them away.
+
+### Exercise 1.1: The Three-Sentence Test
+
+**Task:** Take an idea you want to write about. Write three sentences:
+1. **What** is this about?
+2. **Why** does it matter?
+3. **What** would the "how" section need to cover?
+
+<details>
+<summary>Hint: If your "why" feels weak</summary>
+
+Ask yourself: "What would the reader lose by not reading this?" or "What do most people get wrong about this topic?" If you can't answer either, you may need a stronger angle — not a different topic.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+> **What:** This piece is about how AI coding tools change the learning curve for junior developers.
+> **Why:** Companies are adopting these tools assuming they help everyone equally, but they may actually prevent juniors from building the foundational understanding that makes seniors effective.
+> **How:** I'd need to cover how learning-by-struggling works, what the tools replace, specific examples of skills that atrophy, and what teams should do instead.
+
+Notice how the "why" creates stakes — there's a real consequence if the reader ignores this.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain the reader's transaction in your own words
+- [ ] Articulate the What, Why, and How of your chosen idea
+- [ ] Describe why specificity matters more than abstraction in openings
+
+---
+
+## Section 2: The Lead and the Hook
+
+### The Most Important Sentence
+
+The most important sentence in any piece is the first one. If it doesn't pull the reader into the second sentence, the piece is dead. William Zinsser calls this "the lead," and he's unequivocal: "The most important sentence in any article is the first one. If it doesn't induce the reader to proceed to the second sentence, your article is dead."
+
+### What a Lead Does
+
+A lead does two things simultaneously:
+1. **Grabs attention** — makes the reader stop and focus
+2. **Makes a promise** — signals what the piece is about and why it's worth reading
+
+A hook only does the first. A clickbait headline is a hook — it grabs you but promises nothing specific. A good lead grabs you *and* tells you what you're in for.
+
+### Types of Leads That Work
+
+**The Surprising Fact:**
+> Americans spend more time on their phones than they do sleeping. Not slightly more — substantially more: an average of 7 hours and 4 minutes of screen time versus 6 hours and 54 minutes of sleep.
+
+**The Provocative Question:**
+> What if everything you've been told about productivity is optimized for the wrong century?
+
+**The Scene-Setting Anecdote:**
+> The meeting was eleven minutes old when the CEO interrupted the head of engineering to ask a question nobody in the room wanted to answer: "Does anyone here actually use our product?"
+
+**The Counterintuitive Claim:**
+> The best way to become a faster writer is to spend more time not writing.
+
+**The Personal Anecdote:**
+> I spent three years building an app nobody used. Not because the app was bad — it solved a real problem — but because I'd never once talked to the people who had the problem.
+
+### Why Most Openings Fail
+
+Bad openings almost always fail the same way: they're **abstract, generic, or full of throat-clearing**. Throat-clearing is everything you write before you actually say something — background, caveats, definitions, scene-setting that doesn't set a scene.
+
+> "In today's rapidly evolving technological landscape, it is becoming increasingly important to consider the implications of artificial intelligence on various aspects of modern life."
+
+That sentence says nothing. It could open any of ten thousand articles. Compare:
+
+> "Last Tuesday, an AI wrote my performance review. It was more accurate than the one my manager wrote."
+
+Same general topic. One is dead on arrival; the other makes you want to know what happened next.
+
+### The Pattern: Specific → General
+
+The best nonfiction openings drop the reader into something **specific and concrete**, then zoom out to reveal the larger point. Start with a person, a scene, a number, a moment — something the reader can see. Then expand to the idea.
+
+Zinsser calls surprise "the most refreshing element in nonfiction writing." Michael Lewis is a master of this: he opens with an oddity — a person doing something unexpected — and only later reveals the systemic insight underneath.
+
+### Exercise 2.1: Five Leads for One Idea
+
+**Task:** Write five different leads for your idea — one of each type:
+1. A surprising fact or statistic
+2. A provocative question
+3. A scene-setting anecdote (real or constructed)
+4. A counterintuitive claim
+5. A personal anecdote
+
+Then read all five and ask: which one makes me want to keep writing?
+
+<details>
+<summary>Hint: If you can't find a surprising fact</summary>
+
+You don't need a statistic. A surprising fact can be an observation: "Most developers never read the documentation for the tools they use daily." The surprise is in the specificity and the recognition — the reader thinks "wait, that's true."
+</details>
+
+<details>
+<summary>Hint: If your anecdote lead feels flat</summary>
+
+Make sure you're starting in the middle of action, not before it. "I was sitting in a meeting when..." is weaker than "The meeting was eleven minutes old when..." Drop the reader into the moment.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain the difference between a hook and a lead
+- [ ] Identify throat-clearing in an opening paragraph
+- [ ] Write at least three different lead types for the same idea
+- [ ] Pick the lead that creates the most forward momentum for your piece
+
+---
+
+## Section 3: Structure and Flow
+
+### Why Structure Matters
+
+Structure is what separates a piece that works from a pile of interesting observations that don't add up to anything. You can have brilliant insights, vivid examples, and a killer opening — but without a structure that connects them, the reader just gets a series of moments that don't build.
+
+Zinsser puts it plainly: "Writing is linear and sequential." The reader can only process one idea at a time, in the order you present them. Logic is the glue. Each sentence must follow from the one before it. Each paragraph must answer a question the previous paragraph raised.
+
+### Four Common Nonfiction Structures
+
+#### 1. Sequential / How-To
+Step-by-step toward a result. Best for instructional content.
+
+> First, identify the problem. Then gather your data. Then analyze it. Then present your findings.
+
+**Use when:** You're teaching someone to do something in a specific order.
+
+#### 2. Thesis-Driven
+Central argument supported by evidence and examples. Best for opinion and analysis pieces.
+
+> Here's what I believe → Here's why (evidence 1, evidence 2, evidence 3) → Here's what this means.
+
+**Use when:** You have a point to make and need to build a case.
+
+#### 3. Narrative
+Chronological or character-driven retelling of real events. Best for long-form and case studies.
+
+> Something happened → It led to this → Which caused this → And here's what it means.
+
+**Use when:** The sequence of events itself tells the story and carries the argument.
+
+#### 4. List / Collection
+Curated set of items around a theme. Best for reference content.
+
+> Here are seven ways to... / The five most important... / Three lessons from...
+
+**Use when:** You're cataloging rather than arguing. But be warned — this is the structure most first-time writers default to, and it's often the weakest. Lists don't build an argument; they collect observations. The reader gets information but not momentum.
+
+### The Fat Outline
+
+Josh Bernoff's "fat outline" method is the most practical tool for planning a piece. Instead of a skeletal outline (I, II, III with Roman numerals), you create a **detailed inventory of every element** that will go into a section — anecdotes, data points, arguments, examples, quotes — and then arrange them.
+
+The process:
+1. **Dump everything.** Write down every fragment you have: stats, stories, opinions, examples, counterarguments.
+2. **Group related items.** Cluster them into natural sections.
+3. **Order the sections.** What needs to come first for the rest to make sense?
+4. **Order within sections.** What's the strongest opening for each section? What's the natural conclusion?
+
+The fat outline works because it separates **what to include** from **how to arrange it**. Most writers try to do both at once and get paralyzed.
+
+### Transitions: The Glue
+
+Each paragraph should answer the question the previous paragraph raised in the reader's mind. If paragraph A says "There are three common mistakes," paragraph B should address the first mistake — not jump to something unrelated.
+
+Good transitions are invisible. The reader should feel pulled forward without noticing the tug. Bad transitions announce themselves: "Now let's turn to..." or "Another important point is..." If you need a phrase like that, the paragraphs probably aren't in the right order.
+
+### Exercise 3.1: Build a Fat Outline
+
+**Task:** Take your idea and create a fat outline. List every fragment you have — stats, anecdotes, arguments, examples, counterarguments. Then sort them into one of the four structures above. Which structure makes the strongest case?
+
+<details>
+<summary>Hint: How to choose a structure</summary>
+
+Ask yourself: Is this piece primarily *teaching* something (sequential)? *Arguing* something (thesis-driven)? *Recounting* something (narrative)? Or *cataloging* something (list)? If you're unsure, try thesis-driven — it's the most versatile.
+</details>
+
+<details>
+<summary>Hint: If your outline feels disorganized</summary>
+
+Try reading just the first sentence of each section in order. Does it flow? If not, rearrange until it does. The section-level logic should be clear even without the details.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Name the four common nonfiction structures and when each works best
+- [ ] Explain why "list" is often the weakest default
+- [ ] Build a fat outline from raw material
+- [ ] Describe what makes a good transition between paragraphs
+
+---
+
+## Section 4: Clarity and Concision
+
+### The Core Principle: Simplicity
+
+William Zinsser's central argument is that good writing is simple writing. Not simplistic — simple. Every sentence should be stripped to its cleanest components.
+
+> "The secret of good writing is to strip every sentence to its cleanest components. Every word that serves no function, every long word that could be a short word, every adverb that carries the same meaning that's already in the verb, every passive construction that leaves the reader unsure of who is doing what — these are the thousand and one adulterants that weaken the strength of a sentence."
+
+This isn't about dumbing things down. It's about respecting the reader's time and attention. A clear sentence isn't less sophisticated than a complicated one — it's more sophisticated, because it required more work from the writer.
+
+### Active vs. Passive Voice
+
+**Active:** The engineer designed the system.
+**Passive:** The system was designed by the engineer.
+
+Active voice is almost always clearer because it answers the reader's natural question: **who did what?** Passive voice hides the actor and often adds unnecessary words.
+
+There are legitimate uses for passive voice — when the actor is unknown ("The building was constructed in 1892") or when the action matters more than the actor ("The data was corrupted"). But if you can identify who's doing the action, use active voice.
+
+### Spotting and Killing Clutter
+
+Clutter is the disease of writing. Here are the most common offenders:
+
+| Cluttered | Clean |
+|---|---|
+| at this point in time | now |
+| due to the fact that | because |
+| in terms of | (usually just delete it) |
+| it is important to note that | (delete and just note it) |
+| the fact that | that |
+| in order to | to |
+| a large number of | many |
+| is able to | can |
+
+And the adverb family that almost never adds meaning: *really, very, quite, somewhat, rather, fairly, basically, actually, literally* (when not literal), *honestly* (which paradoxically makes readers trust you less).
+
+**The test:** Read each sentence and ask, "Would this mean the same thing if I cut this word?" If yes, cut it.
+
+### Progressive Disclosure
+
+When you're explaining something complex, don't frontload every caveat and exception. State the core idea simply. Then add nuance incrementally.
+
+Bad (frontloaded):
+> While there are several important exceptions and edge cases that we'll discuss later, and acknowledging that this is a simplification of a more nuanced reality, the general principle is that higher interest rates reduce borrowing.
+
+Good (progressive):
+> Higher interest rates reduce borrowing. That's the core mechanism. But there are important exceptions — and understanding them is where it gets interesting.
+
+The first version buries the point under caveats. The second states the point, then earns the reader's attention for the complexity.
+
+### Reading Aloud
+
+The single most effective editing technique is reading your work aloud. Your ear catches things your eye misses: awkward rhythms, repeated words, sentences that run too long, transitions that don't transition.
+
+If a sentence makes you stumble when you read it aloud, it will make the reader stumble too. Rewrite it.
+
+### Exercise 4.1: The 30% Cut
+
+**Task:** Take a paragraph you've written (from your outline, your lead, or earlier exercises). Cut it by 30% without losing meaning. Count the words before and after. Read both versions aloud.
+
+<details>
+<summary>Hint: Where to cut first</summary>
+
+Start with: adverbs (very, really, quite), hedge words (somewhat, rather), throat-clearing phrases (it is important to note that), and any sentence that restates what the previous sentence already said.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+**Before (67 words):**
+> It is really important to understand that the basic fundamental principle behind effective nonfiction writing is actually quite simple when you think about it. Essentially, you need to make sure that every single word in your sentence is serving a very specific and clear function, and if it isn't doing that, you should probably consider removing it from the sentence entirely.
+
+**After (25 words):**
+> The principle behind effective nonfiction is simple: every word must serve a function. If it doesn't, cut it.
+
+Same meaning. Less than half the words. The revision is faster to read and harder to misunderstand.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain why simplicity is not the same as dumbing down
+- [ ] Convert passive voice to active voice
+- [ ] Identify at least five clutter words/phrases in your own writing
+- [ ] Explain progressive disclosure and why it matters for complex topics
+
+---
+
+## Section 5: Voice and the Personal Transaction
+
+### What Voice Is
+
+Readers read nonfiction not just for information but for the writer's perspective. Your voice — the way you see things, the connections you draw, the tone you strike — is the product. Two people can write about the same topic with the same facts and produce completely different pieces. The difference is voice.
+
+**Voice** is who you are on the page. **Style** is the set of choices you make — sentence length, formality, humor, directness. Style serves voice. You can adjust your style for different contexts (a blog post vs. a formal report) while your voice remains recognizable.
+
+### The Worst Writing Advice: "Sound Like a Writer"
+
+Trying to sound like a "writer" produces the worst writing. It leads to long words where short ones work, passive constructions that hide behind formality, and sentences that impress nobody because they communicate nothing.
+
+Zinsser's advice: **write like you talk, then clean it up.** Your spoken voice is natural, direct, and alive. The page makes you self-conscious, and self-consciousness produces stiff prose. The fix is to get your natural voice down first, then edit for clarity — not to start formal and try to inject personality later.
+
+### Personal Anecdotes: Vehicles, Not Destinations
+
+Personal anecdotes are powerful in nonfiction because they create trust and specificity. But the anecdote is a **vehicle**, not the destination. It should carry the reader toward your point, not circle around your experience.
+
+Bad: An anecdote that exists to show the writer had an interesting experience.
+Good: An anecdote that illustrates a principle the reader can apply.
+
+The test: after the anecdote, can you write "and the reason this matters is..." and complete the sentence? If not, the anecdote needs a frame or a different home.
+
+### Finding Your Natural Register
+
+Your natural register is the mode you default to when you're not performing. Some writers are naturally:
+- **Explanatory** — they want to make complex things clear
+- **Argumentative** — they want to convince you of something
+- **Observational** — they notice things others miss and point them out
+- **Comedic** — they find the absurd angle on everything
+
+Understanding your register shapes what formats work for you. An observational writer may struggle with how-to content but thrive writing essays. An argumentative writer may find narrative boring to write but produce excellent opinion pieces.
+
+### Exercise 5.1: Three Registers
+
+**Task:** Write the same 200-word take on your topic three times:
+1. **Formal**: As if writing for a professional publication
+2. **Conversational**: As if explaining to a friend
+3. **Irreverent**: As if you're slightly annoyed and being honest about it
+
+Which one sounds most like you? That's your starting point.
+
+<details>
+<summary>Hint: If they all sound the same</summary>
+
+Try the irreverent version again, but this time actually let yourself be a little rude about it. Don't censor. The point isn't to publish the irreverent version — it's to find the edges of your voice so you can pull back to a comfortable middle.
+</details>
+
+<details>
+<summary>Hint: If the conversational version feels "too casual"</summary>
+
+That's usually the voice you want. "Too casual" often means "too natural" — your inner editor is rejecting it because it doesn't sound like what you think writing should sound like. Edit for clarity and precision, not for formality.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain the difference between voice and style
+- [ ] Identify your natural register
+- [ ] Use a personal anecdote to illustrate a point (not just to tell a story)
+- [ ] Write in a tone that sounds like you, not like you performing "writer"
+
+---
+
+## Section 6: Endings and Knowing When to Stop
+
+### Zinsser's Rule
+
+When you're ready to stop, stop. Don't summarize what you've already said. Don't repeat your thesis. Don't trail off with a vague gesture toward the future. The reader has been with you the whole way — they don't need a recap.
+
+The ending should leave the reader with **one provocative thought they didn't have before**. Not a summary. Not a call to action (unless you're writing a how-to). A thought.
+
+### Types of Strong Endings
+
+**The Callback:** Circle back to the opening image, anecdote, or question — but now the reader sees it differently because of what they've learned.
+
+**The Forward Look:** Point toward what comes next — not vaguely ("the future will be interesting") but specifically ("the next time you open your IDE, notice how many decisions the tool is making for you").
+
+**The Surprising Detail:** End with a specific, concrete detail that encapsulates the whole piece. McPhee is a master of this — ending long pieces with a single image that resonates.
+
+**The Resonant Quote:** A quote from someone in the piece that captures the essence of what you've been arguing. It works because it shifts the final word from you to someone the reader has come to know.
+
+### When Endings Are Hard
+
+If you can't find your ending, the problem usually isn't the ending — it's the structure. You don't know how to end because you haven't clarified what the piece is *really* about.
+
+The question that unlocks everything: **"What is this piece *really* about?"** Not "what is it about?" — that's the topic. "What is it *really* about?" — that's the point. Once you can answer that in one sentence, the ending usually becomes obvious. It's the sentence that delivers that point.
+
+### Exercise 6.1: Write the Ending First
+
+**Task:** Write an ending for your piece before you write the middle. Try two different types (callback, forward look, surprising detail, or resonant quote). Which one makes the destination clearer? Does having the ending make the journey easier to plan?
+
+<details>
+<summary>Hint: If you can't write an ending</summary>
+
+Answer this question first: "After reading my piece, what is the one thing I want the reader to carry with them?" Write that down. Now turn it into a final paragraph.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain why summaries make weak endings
+- [ ] Write at least two types of endings
+- [ ] Answer "What is this piece *really* about?" in one sentence
+- [ ] Recognize when a bad ending signals a structural problem
+
+---
+
+## Practice Project: Assemble Your Piece
+
+Through the exercises, you've been building the components of a complete nonfiction piece. Now put them together.
+
+### What You Should Have
+
+From the exercises, you should have:
+- A What/Why/How framework (Exercise 1.1)
+- A lead — your best of the five you wrote (Exercise 2.1)
+- A fat outline with structure (Exercise 3.1)
+- A revised paragraph demonstrating clarity (Exercise 4.1)
+- A voice sample in your natural register (Exercise 5.1)
+- An ending (Exercise 6.1)
+
+### The Task
+
+Assemble these into a complete **800-1500 word** nonfiction piece. Write it end-to-end.
+
+### Steps
+
+**Step 1: Arrange your outline.** Put your lead at the top, your ending at the bottom, and arrange your fat outline sections between them. Does the sequence build logically?
+
+**Step 2: Write the draft.** Go end-to-end without stopping to edit. If a section is hard, write "[COME BACK TO THIS]" and keep going. The goal is a complete draft, not a perfect one.
+
+**Step 3: Let it sit.** Walk away for at least a few hours, ideally overnight.
+
+**Step 4: Revise.** Read the whole piece aloud. Use this checklist:
+
+### Revision Checklist
+
+- [ ] **Lead:** Does the first sentence make you want to read the second?
+- [ ] **Promise:** Is it clear within the first few paragraphs what the reader will get?
+- [ ] **Structure:** Does each section follow logically from the one before it?
+- [ ] **Transitions:** Does each paragraph answer a question raised by the previous one?
+- [ ] **Clutter:** Have you cut unnecessary words, adverbs, and hedge phrases?
+- [ ] **Voice:** Does it sound like you, not like you performing "writer"?
+- [ ] **Active voice:** Are most sentences in active voice?
+- [ ] **Progressive disclosure:** Are complex ideas introduced simply before nuance is added?
+- [ ] **Ending:** Does it leave the reader with a thought, not a summary?
+- [ ] **The real test:** Read it aloud. Where do you stumble? Fix those parts.
+
+<details>
+<summary>If you're stuck assembling the pieces</summary>
+
+Don't try to connect everything smoothly on the first pass. Just paste your lead, outline sections, and ending into one document. Then fill in the gaps with rough prose. The connections will reveal themselves during revision.
+</details>
+
+<details>
+<summary>If the draft feels too short</summary>
+
+You probably need more substance in the "How" section. Go back to your fat outline — what examples, evidence, or anecdotes did you list but not include? Add the strongest ones.
+</details>
+
+<details>
+<summary>If the draft feels too long</summary>
+
+Apply King's formula: second draft = first draft minus 10%. Cut the weakest example from each section. Cut any paragraph that restates what the previous one said. Cut your throat-clearing.
+</details>
+
+---
+
+## Summary
+
+### Key Takeaways
+
+- **Nonfiction is a transaction.** Clarity and substance are what you owe the reader.
+- **The lead is everything.** If the first sentence doesn't pull the reader forward, nothing else matters.
+- **Structure is not optional.** A pile of good observations is not the same as a good piece.
+- **Simplicity is hard work.** Clear writing comes from ruthless revision, not first-draft talent.
+- **Voice is the product.** Readers come for your perspective, not just your information.
+- **Endings deliver the point.** When you're ready to stop, stop.
+
+### Skills You've Gained
+
+You can now:
+- ✓ Frame any idea using What → Why → How
+- ✓ Write multiple lead types and choose the strongest
+- ✓ Structure a piece using fat outlines and one of four frameworks
+- ✓ Edit for clarity, cutting clutter and using active voice
+- ✓ Write in your natural voice
+- ✓ End a piece with impact, not summary
+
+### Self-Assessment
+
+- Which section felt most transformative for your writing?
+- Where do you still feel least confident?
+- Did your finished piece surprise you in any way?
+
+---
+
+## Next Steps
+
+### Continue Learning
+
+- **[Storytelling](/routes/storytelling/map.md)** — Learn narrative structure, character, and scene craft
+- **[Writing Foundations](/routes/writing-foundations/map.md)** — If you haven't taken it, the idea-to-output pipeline and failure modes
+
+### Practice More
+
+- **Write three leads a week.** For anything — articles you read, ideas you have, topics that annoy you. The lead is a muscle.
+- **Revise someone else's writing.** Editing other people's prose trains your eye faster than editing your own.
+- **Publish something.** A blog post, a newsletter issue, a long social media post. The feedback loop of real readers is irreplaceable.
+
+### Additional Resources
+
+- William Zinsser, *On Writing Well* — The definitive guide to nonfiction craft
+- Strunk & White, *The Elements of Style* — The mechanical foundation
+- John McPhee, *Draft No. 4* — A master on structure, leads, and process
+- Josh Bernoff, *Build a Better Business Book* — The fat outline method
+- George Orwell, "Politics and the English Language" — Six rules for clear writing
+- Anne Lamott, *Bird by Bird* — Permission to write badly
+
+---
+
+## Appendix
+
+### Orwell's Six Rules
+
+1. Never use a metaphor, simile, or other figure of speech which you are used to seeing in print.
+2. Never use a long word where a short one will do.
+3. If it is possible to cut a word out, always cut it out.
+4. Never use the passive where you can use the active.
+5. Never use a foreign phrase, a scientific word, or a jargon word if you can think of an everyday English equivalent.
+6. Break any of these rules sooner than say anything outright barbarous.
+
+### Clutter Words Quick Reference
+
+Words and phrases to cut or replace:
+
+| Cut This | Use This |
+|---|---|
+| at this point in time | now |
+| due to the fact that | because |
+| in order to | to |
+| it is important to note that | (just note it) |
+| the fact that | that |
+| in terms of | (delete) |
+| a large number of | many |
+| is able to | can |
+| utilize | use |
+| implement | do / make / build |
+| leverage | use |
+| really / very / quite / rather | (usually delete) |
+| basically / essentially / honestly | (delete) |
+
+### Lead Types Quick Reference
+
+| Lead Type | What It Does | Example Opening |
+|---|---|---|
+| Surprising fact | Disrupts expectations | "Americans spend more on pet costumes than on..." |
+| Provocative question | Creates curiosity | "What if everything you know about X is wrong?" |
+| Scene-setting anecdote | Drops reader into a moment | "The meeting was eleven minutes old when..." |
+| Counterintuitive claim | Challenges assumptions | "The best way to X is to stop doing Y." |
+| Personal anecdote | Creates trust through specificity | "I spent three years building something nobody used." |
+
+### Structure Quick Reference
+
+| Structure | Best For | Key Question |
+|---|---|---|
+| Sequential / How-to | Instructional content | "What steps does the reader need to follow?" |
+| Thesis-driven | Opinion / analysis | "What am I arguing and what's my evidence?" |
+| Narrative | Long-form / case studies | "What happened, and what does it mean?" |
+| List / Collection | Reference content | "What items belong together?" |

--- a/routes/nonfiction-writing/map.md
+++ b/routes/nonfiction-writing/map.md
@@ -1,0 +1,95 @@
+---
+title: Nonfiction Writing
+topics:
+  - Nonfiction Craft
+  - Leads
+  - Structure
+  - Clarity
+  - Voice
+  - Revision
+related_routes:
+  - writing-foundations
+  - storytelling
+---
+
+# Nonfiction Writing — Route Map
+
+## Overview
+
+You have ideas worth sharing — about technology, culture, how things work, how they should work. But sitting down to actually write them out feels like a different skill entirely. This route teaches you the craft of nonfiction: how to take a raw idea and turn it into something someone else can follow, learn from, and act on. You'll learn how the best explanatory writers structure their thinking, how to write openings that pull people in, and how to write clearly without dumbing things down.
+
+## What You'll Learn
+
+By following this route, you will:
+- Take a raw idea or observation and determine what kind of nonfiction piece it wants to be
+- Build a structural plan for a piece before drafting it
+- Write leads that create genuine forward momentum
+- Explain complex ideas clearly using concrete examples and progressive disclosure
+- Edit your own work for clarity, concision, and logical flow
+- Identify and eliminate clutter, jargon, and hedging in your prose
+
+## Prerequisites
+
+Before starting this route:
+- **Required**: Experience writing in English (emails, blog posts, reports, anything)
+- **Helpful**: [Writing Foundations](/routes/writing-foundations/map.md) route — the idea-to-output pipeline and common failure modes
+
+## Route Structure
+
+### 1. What Makes Nonfiction Work
+- The reader's implicit question: "Why should I keep reading?"
+- Writing for yourself vs. writing for an audience
+- The What → Why → How framework
+
+### 2. The Lead and the Hook
+- The most important sentence is the first one
+- Types of leads: surprising fact, provocative question, scene-setting anecdote, counterintuitive claim
+- The difference between a hook and a lead
+
+### 3. Structure and Flow
+- Four common nonfiction structures: sequential, thesis-driven, narrative, list/collection
+- The "fat outline" method for planning
+- Transitions as glue between paragraphs
+
+### 4. Clarity and Concision
+- Simplicity as a principle, not a dumbing-down
+- Active vs. passive voice
+- Spotting and cutting clutter words
+- Progressive disclosure for complex ideas
+
+### 5. Voice and the Personal Transaction
+- Voice vs. style
+- Writing like you talk, then cleaning it up
+- Using personal anecdotes as vehicles, not destinations
+
+### 6. Endings and Knowing When to Stop
+- When you're ready to stop, stop
+- Types of strong endings: callback, forward look, surprising detail, resonant quote
+- The editing question: "What is this piece really about?"
+
+### 7. Practice Project
+- Assemble a complete 800-1500 word nonfiction piece from the exercises
+
+## Learning Modes
+
+This route supports three learning modes:
+
+1. **Self-guided**: Read the guide.md file and work through exercises at your own pace
+2. **AI-guided**: Work with an AI assistant using the sherpa.md teaching script
+3. **Collaborative**: Read guide.md while getting help from AI following sherpa.md
+
+## Tools & Techniques
+
+This route references:
+- William Zinsser, *On Writing Well* — clarity, simplicity, and nonfiction craft
+- Strunk & White, *The Elements of Style* — grammar and composition fundamentals
+- Josh Bernoff, *Build a Better Business Book* — the "fat outline" method
+- John McPhee, *Draft No. 4* — structure, leads, and the writing process
+- George Orwell, "Politics and the English Language" — six rules for clear writing
+- Anne Lamott, *Bird by Bird* — permission to write badly and dealing with perfectionism
+
+## Next Steps
+
+After completing this route:
+- **[Storytelling](/routes/storytelling/map.md)** — Learn narrative structure, character, and scene craft
+- **[Writing Foundations](/routes/writing-foundations/map.md)** — If you haven't taken it, the idea-to-output pipeline

--- a/routes/nonfiction-writing/sherpa.md
+++ b/routes/nonfiction-writing/sherpa.md
@@ -1,0 +1,461 @@
+---
+title: Nonfiction Writing
+route_map: /routes/nonfiction-writing/map.md
+paired_guide: /routes/nonfiction-writing/guide.md
+topics:
+  - Nonfiction Craft
+  - Leads
+  - Structure
+  - Clarity
+  - Voice
+  - Revision
+---
+
+# Nonfiction Writing — Sherpa (AI Teaching Guide)
+
+**Purpose**: This sherpa guide helps AI assistants teach nonfiction writing craft — how to structure, lead, clarify, and finish explanatory and persuasive writing.
+
+**Route Map**: See `/routes/nonfiction-writing/map.md` for the high-level overview.
+**Paired Guide**: The human-focused content is at `/routes/nonfiction-writing/guide.md`.
+
+---
+
+## Teaching Overview
+
+### Learning Objectives
+By the end of this session, the learner should be able to:
+- Take a raw idea and determine what kind of nonfiction piece it wants to be
+- Build a structural plan before drafting
+- Write leads that create genuine forward momentum
+- Explain complex ideas clearly using concrete examples and progressive disclosure
+- Edit their own work for clarity, concision, and logical flow
+- Identify and eliminate clutter, jargon, and hedging in their prose
+
+### Prior Sessions
+Before starting, check `.sessions/index.md` and `.sessions/nonfiction-writing/` for prior session history. If the learner has completed previous sessions, review summaries to pick up where they left off.
+
+### Prerequisites to Verify
+Before starting, verify the learner has:
+- Experience writing in English (any kind)
+- Ideally, an idea they want to develop (if not, Section 1 exercises will generate one)
+- Optionally, completed the Writing Foundations route
+
+**If they've done Writing Foundations**: They should have an outline or draft from that route. Build on it. Skip the basics of idea development and move faster through Section 1.
+
+**If they haven't**: Spend more time on Section 1 establishing the What/Why/How framework. They'll need to develop an idea from scratch.
+
+### Learner Preferences Configuration
+
+Learners can configure their preferred learning style by creating a `.sherpa-config.yml` file in the repository root (gitignored by default). Configuration options include:
+
+**Teaching Style:**
+- `tone`: objective, encouraging, humorous (default: objective and respectful)
+- `explanation_depth`: concise, balanced, detailed
+- `pacing`: learner-led, balanced, structured
+
+**Assessment Format:**
+- `quiz_type`: multiple_choice, explanation, mixed (default: mixed)
+- `quiz_frequency`: after_each_section, after_major_topics, end_of_route
+- `feedback_style`: immediate, summary, detailed
+
+If no configuration file exists, use defaults.
+
+### Assessment Strategies
+
+Writing assessment is subjective. Focus on evaluable structural choices:
+
+**Structural Questions:**
+- Does the lead create forward momentum?
+- Does the structure have a clear logic?
+- Does each section earn its place?
+
+**Craft Questions:**
+- Is the prose clear and free of clutter?
+- Is the voice consistent and natural?
+- Does the piece have a point and does the ending deliver it?
+
+**Process Questions:**
+- Can the learner articulate why they made specific choices?
+- Can they identify weaknesses in their own writing?
+
+---
+
+## Teaching Flow
+
+### Introduction
+
+**What to Cover:**
+- Nonfiction writing is a craft — it can be learned through practice and principles
+- This route covers the full arc: from opening to ending, from idea to polished piece
+- By the end, they'll have a complete 800-1500 word piece
+
+**Opening Questions to Assess Level:**
+1. "What kind of nonfiction do you want to write — blogs, essays, analysis, how-to guides, something else?"
+2. "Do you have a piece in progress or an idea you want to develop?"
+3. "What's the hardest part of writing for you — starting, structuring, or finishing?"
+
+**Adapt based on responses:**
+- If they have a piece in progress: Use it as the working material throughout
+- If they're starting fresh: Help them develop an idea in Section 1
+- If starting is hard: Sections 1-2 (framework and leads) will help most
+- If structuring is hard: Section 3 is their critical section
+- If finishing is hard: Sections 4-6 (clarity, voice, endings) and the practice project
+
+---
+
+### Section 1: What Makes Nonfiction Work
+
+**Core Concept to Teach:**
+Good nonfiction is a transaction between writer and reader. The reader gives time; the writer owes clarity, substance, and forward momentum. The What → Why → How framework is the simplest reliable skeleton.
+
+**How to Explain:**
+1. Start with the reader's question: "Every reader, from the first sentence, is asking 'Why should I keep reading?' Your job is to answer that question, over and over, until the piece is done."
+2. Explain the transaction: "Writing for yourself is different from writing for an audience. A journal entry can wander. A published piece owes the reader a clear purpose, a logical path, and a payoff."
+3. Introduce What → Why → How: "The simplest skeleton for any nonfiction piece. What are you covering? Why does it matter? How does it work?"
+4. Use an example: Take a topic the learner cares about and walk through the three parts together.
+
+**Common Misconceptions:**
+- Misconception: "If the idea is interesting enough, the writing doesn't matter." → Clarify: An interesting idea badly presented is just a missed opportunity. The reader doesn't know the idea is interesting until you make it interesting on the page.
+- Misconception: "Nonfiction is just presenting facts." → Clarify: Nonfiction is facts shaped by perspective, structure, and voice. The same facts produce completely different pieces depending on how you organize and present them.
+- Misconception: "I need to know everything about the topic before writing." → Clarify: Writing is how you figure out what you think. You don't need expertise — you need a perspective and the willingness to support it.
+
+**Verification Questions:**
+1. "What's the difference between writing for yourself and writing for an audience?"
+2. "Can you walk me through the What, Why, and How of your idea?"
+3. "Who is your reader, and why would they care about this?"
+
+**Good answer indicators:**
+- They understand the reader's question ("why should I keep reading?") as the organizing principle
+- They can articulate all three parts of their framework
+- They can identify a specific reader, not just "everyone"
+
+**If they struggle:**
+- Ask: "If you were telling a friend about this idea, what would you say first?" That's usually the What.
+- Ask: "Why did this idea grab you? What made you care?" That's usually the Why.
+- Then: "What would someone need to know to understand your point?" That's the How.
+
+**Exercise 1.1: The Three-Sentence Test**
+"Write three sentences: What is this about? Why does it matter? What would the How section need to cover?"
+
+**How to Guide Them:**
+1. If their What is too broad: "Can you make it more specific? 'AI in education' is a topic. 'How AI tools prevent junior developers from learning' is a What."
+2. If their Why is weak: "What does the reader lose by not knowing this? What goes wrong if they ignore it?"
+3. If their How is vague: "List three specific things you'd need to explain for the reader to understand your point."
+
+---
+
+### Section 2: The Lead and the Hook
+
+**Core Concept to Teach:**
+The first sentence is the most important. It must pull the reader into the second sentence. A lead both grabs attention and makes a promise about what the piece delivers.
+
+**How to Explain:**
+1. State the principle directly: "Zinsser says the most important sentence in any article is the first one. If it doesn't induce the reader to proceed to the second sentence, your article is dead."
+2. Distinguish hook from lead: "A hook grabs attention. A lead grabs attention AND tells the reader what they're in for. Clickbait is a hook. A good opening paragraph is a lead."
+3. Present lead types with examples. Show each type applied to the same topic so the learner can compare.
+
+**Lead Types to Present:**
+
+Present these with examples, ideally using the learner's topic:
+
+1. **Surprising fact**: A specific, unexpected detail that disrupts expectations
+2. **Provocative question**: A question the reader can't help but want answered
+3. **Scene-setting anecdote**: Drop the reader into a specific moment
+4. **Counterintuitive claim**: Challenge something the reader assumes is true
+5. **Personal anecdote**: A specific experience that illustrates the larger point
+
+**The Pattern to Emphasize:**
+The best openings start specific and concrete, then zoom out. Start with a person, a scene, a number — then reveal the larger idea.
+
+**Common Misconceptions:**
+- Misconception: "The lead has to be clever or witty." → Clarify: It has to be honest and compelling. Cleverness without substance is just performance.
+- Misconception: "Start with background and context." → Clarify: That's throat-clearing. The reader doesn't need background until they care about the topic. The lead's job is to make them care.
+- Misconception: "Start with a dictionary definition." → Clarify: Never. "Webster's defines X as..." is the weakest possible opening. It signals that you don't have anything original to say.
+
+**Verification Questions:**
+1. "Read me your best lead. What does it promise the reader?"
+2. "Which of the five lead types was easiest for you? Which was hardest?"
+3. "If you read just your first sentence, would you keep reading?"
+
+**If they struggle:**
+- Ask them to explain their topic out loud, casually. Often the first thing they say is a better lead than what they wrote.
+- Try the anecdote approach: "Is there a specific moment — something that happened to you or someone you know — that captures why this topic matters?"
+- If all five leads feel weak: "Which one makes YOU want to keep writing? That's the one."
+
+**Exercise 2.1: Five Leads**
+"Write five different leads for your idea — one of each type. Then pick the strongest."
+
+**How to Guide Them:**
+1. Review each lead without immediately picking a winner. Ask what each one promises.
+2. Ask: "Which one gives the reader the clearest sense of what the piece is about?"
+3. Ask: "Which one creates the most forward momentum — the strongest urge to read the next sentence?"
+4. If they're attached to a weak lead, don't argue — ask: "What would you need to add to this lead to make the reader's next question obvious?"
+
+---
+
+### Section 3: Structure and Flow
+
+**Core Concept to Teach:**
+Structure is what separates a piece that works from a pile of interesting observations. There are four common structures for nonfiction, and the "fat outline" method is the most practical planning tool.
+
+**How to Explain:**
+1. Start with why structure matters: "You can have brilliant insights and a killer opening, but without structure, the reader gets a series of moments that don't build toward anything."
+2. Present the four structures briefly — ask which one fits their piece.
+3. Teach the fat outline: "Instead of a Roman numeral outline, dump everything you have — every fact, anecdote, argument, example — into a list. Then group and arrange."
+4. Explain transitions: "Each paragraph should answer a question the previous paragraph raised. If you need to write 'Now let's turn to...' the paragraphs are probably in the wrong order."
+
+**The Four Structures:**
+1. **Sequential/How-to**: Steps toward a result. Best for instruction.
+2. **Thesis-driven**: Argument + evidence. Best for opinion/analysis. Most versatile.
+3. **Narrative**: Events in order, building meaning. Best for long-form.
+4. **List/Collection**: Items around a theme. Most common default, often weakest.
+
+**Common Misconceptions:**
+- Misconception: "Lists are always the easiest structure." → Clarify: Lists are the easiest to start but the hardest to make compelling. They don't build momentum because each item resets the reader's engagement.
+- Misconception: "Structure kills creativity." → Clarify: Structure frees creativity. When you know where you're going, you can focus on how you say things instead of spending energy figuring out what comes next.
+
+**Verification Questions:**
+1. "Which of the four structures fits your piece? Why?"
+2. "Walk me through your fat outline — what are the main sections and why are they in that order?"
+3. "What question does your second section answer that your first section raises?"
+
+**If they struggle:**
+- Help them sort their material physically: "Let's list everything you have. Now which of these go together? Which ones support the same point?"
+- If they can't choose a structure: "What's the single most important thing you want the reader to take away? That usually points to thesis-driven."
+
+**Exercise 3.1: Fat Outline**
+"List every fragment you have. Sort them into sections. Arrange the sections in order. Which structure are you using?"
+
+**How to Guide Them:**
+1. If the outline is too thin: "What examples do you have? What would someone who disagrees say? What's the most surprising thing about this?"
+2. If it's too sprawling: "Which of these sections is essential to your point? Cut the rest — or save them for a separate piece."
+3. Read back their section order and ask: "Does this build? Does each section make the next one more impactful?"
+
+---
+
+### Section 4: Clarity and Concision
+
+**Core Concept to Teach:**
+Good writing is rewriting. The first draft is you telling yourself what you think. The second draft is you making it legible to someone else. Simplicity is the goal — not simplistic, but stripped to essential components.
+
+**How to Explain:**
+1. Quote Zinsser: "The secret of good writing is to strip every sentence to its cleanest components."
+2. Clarify immediately: "Simple doesn't mean dumbed down. A clear sentence is harder to write than a complex one — it requires more thought, not less."
+3. Demonstrate with a before/after. Take a cluttered sentence and show the revision.
+4. Teach the practical tools: active voice, clutter word spotting, progressive disclosure, reading aloud.
+
+**Before/After to Present:**
+
+> Before: "It is really important to understand that the basic fundamental principle behind effective nonfiction writing is actually quite simple when you think about it."
+
+> After: "The principle behind effective nonfiction is simple."
+
+Ask: "Which one do you trust more? Which one sounds like someone who actually knows what they're talking about?"
+
+**Clutter Words to Flag:**
+Present this list: really, very, quite, somewhat, rather, basically, essentially, actually, honestly, literally (when not literal). Phrases: "in terms of," "the fact that," "it is important to note that," "in order to," "at this point in time," "due to the fact that."
+
+**Common Misconceptions:**
+- Misconception: "Short sentences are always better." → Clarify: Rhythm matters. A mix of short and long sentences creates energy. All short sentences sound choppy. All long sentences exhaust the reader. The goal is clarity, not brevity for its own sake.
+- Misconception: "Simple writing means simple ideas." → Clarify: The most complex ideas require the clearest writing. If you can't explain it simply, you may not understand it well enough yet.
+
+**Verification Questions:**
+1. "Read me a sentence from your draft. Can we cut any words without losing meaning?"
+2. "Is this sentence active or passive? Does it matter in this case?"
+3. "What's the core idea of this paragraph in one sentence?"
+
+**If they struggle:**
+- Do a live edit together. Take one of their paragraphs, read it aloud, and identify clutter together.
+- Focus on one technique at a time. Don't ask them to fix voice, clutter, and structure simultaneously.
+- If they resist cutting: "We're not deleting ideas — we're making the ideas land harder by removing the padding."
+
+**Exercise 4.1: The 30% Cut**
+"Take a paragraph you've written. Count the words. Now cut 30% without losing meaning. Read both aloud."
+
+**How to Guide Them:**
+1. Start by identifying the core point: "What is this paragraph's one job?"
+2. Flag clutter: "Do you see any words from the clutter list?"
+3. After they cut: "Read both versions aloud. Which one sounds more like something you'd actually say to someone?"
+
+---
+
+### Section 5: Voice and the Personal Transaction
+
+**Core Concept to Teach:**
+Readers read nonfiction for the writer's perspective. Voice — who you are on the page — is the product. The worst mistake is trying to sound like a "writer" instead of like yourself.
+
+**How to Explain:**
+1. Distinguish voice from style: "Voice is who you are. Style is the choices you make — sentence length, formality, humor. You can adjust style for different contexts while your voice stays recognizable."
+2. The key principle: "Write like you talk, then clean it up. Your spoken voice is natural and alive. The page makes you self-conscious, and self-consciousness kills prose."
+3. On anecdotes: "Personal anecdotes are powerful but they're vehicles, not destinations. The anecdote should carry the reader toward your point, not orbit your experience."
+
+**Common Misconceptions:**
+- Misconception: "Professional writing should sound formal and impersonal." → Clarify: The best professional writing — Zinsser, McPhee, Lewis — is warm, direct, and personal. Formality is not a sign of quality; it's often a sign of insecurity.
+- Misconception: "I don't have a distinctive voice." → Clarify: You do. You just haven't given yourself permission to use it on the page. If you can hold a conversation, you have a voice.
+- Misconception: "Personal anecdotes are self-indulgent." → Clarify: Only if they don't serve the piece. An anecdote that illustrates your point is generous — it gives the reader a concrete example instead of abstract argument.
+
+**Verification Questions:**
+1. "Read me two paragraphs from your draft. Do they sound like the same person wrote them?"
+2. "Which version — formal, conversational, or irreverent — sounds most like you?"
+3. "If I read this without your name on it, could I tell it was you? What makes it yours?"
+
+**If they struggle:**
+- Try the recording technique: "Explain your topic to me out loud, like you're telling a friend. I'll help you capture the best parts."
+- If they're stuck in formal mode: "Pretend you're texting this to a smart friend. How would you say it?"
+- If they can't identify their voice: "Look at the three versions you wrote. Which one are you least embarrassed by? That's usually your real voice — you're not embarrassed because it sounds like you."
+
+**Exercise 5.1: Three Registers**
+"Write the same 200-word take three ways: formal, conversational, irreverent."
+
+**How to Guide Them:**
+1. Don't critique individual versions — compare them. "What's different about how these three handle the same information?"
+2. Ask which feels most natural. If they say "conversational," that's their base. If they say "irreverent," they may need more permission to be themselves.
+3. If all three sound the same, they're probably stuck in one mode. Push them to exaggerate: "Make the formal version stuffier. Make the irreverent one angrier. Now where's the middle?"
+
+---
+
+### Section 6: Endings and Knowing When to Stop
+
+**Core Concept to Teach:**
+The ending should leave the reader with one provocative thought they didn't have before. Don't summarize, don't restate, don't trail off. When you've said what you need to say, stop.
+
+**How to Explain:**
+1. State Zinsser's rule: "When you're ready to stop, stop. The reader doesn't need a recap — they just read the piece."
+2. Present ending types with examples:
+   - **Callback**: Return to the opening image, now transformed by what the reader has learned
+   - **Forward look**: Point to what comes next, specifically
+   - **Surprising detail**: A single concrete image that encapsulates everything
+   - **Resonant quote**: Someone else's words that capture the piece's essence
+3. The diagnostic: "If you can't find your ending, the problem is usually structural. You don't know how to end because you haven't clarified what the piece is *really* about."
+
+**Common Misconceptions:**
+- Misconception: "Always summarize at the end." → Clarify: Summaries are for textbooks. In essays and articles, a summary ending tells the reader you don't trust them to remember what they just read.
+- Misconception: "The ending should restate the thesis." → Clarify: The ending should *deliver* on the thesis — not repeat it. There's a difference between arriving at your destination and announcing that you've arrived.
+
+**Verification Questions:**
+1. "What is this piece *really* about — in one sentence?"
+2. "What's the one thought you want the reader to carry with them?"
+3. "Read me your ending. Does it deliver that thought?"
+
+**If they struggle:**
+- The unlock question: "What is this piece *really* about?" If they can't answer, go back to structure. The ending problem is usually a clarity-of-purpose problem.
+- Try writing the ending as a single sentence first: "What's the one thing?" Then build a paragraph around it.
+- If they default to summary: "Cross out the last paragraph. What's the sentence before it? Is that a better ending?"
+
+**Exercise 6.1: Write the Ending First**
+"Write an ending before the middle. Try two types. Which one clarifies your destination?"
+
+---
+
+## Practice Project
+
+**Project Introduction:**
+"You've been building toward this throughout the route. You have a framework, a lead, an outline, revised paragraphs, a voice sample, and an ending. Now assemble them into a complete piece."
+
+**Requirements:**
+- A complete nonfiction piece of 800-1500 words
+- Clear lead with forward momentum
+- Logical structure with transitions between sections
+- Prose that's been edited for clarity (clutter cut, active voice)
+- Consistent voice
+- An ending that delivers the point
+
+**Scaffolding Strategy:**
+1. **If they want to try alone**: Let them assemble and draft. Offer to review when done.
+2. **If they want guidance**: Walk through it section by section. "Let's start with your lead, then your first section. Read it to me and we'll discuss."
+3. **If they're unsure**: Start with the outline. Paste the lead on top and the ending at the bottom. "Now fill in the middle, section by section."
+
+**Checkpoints During Project:**
+- After assembly: "Read me the lead and the first transition. Does it flow?"
+- Midway: "Read a section aloud. Where do you stumble? Those are the spots to revise."
+- Near completion: "What's your piece *really* about? Does your ending deliver it?"
+- After draft: "Let it sit if you can. Then do a revision pass using the checklist."
+
+**Revision Checklist to Walk Through:**
+1. Does the lead pull the reader into the second sentence?
+2. Is the promise clear within the first few paragraphs?
+3. Does each section follow logically from the previous one?
+4. Is the prose free of clutter?
+5. Does it sound like you?
+6. Does the ending deliver the point without summarizing?
+
+**If They Get Stuck:**
+- Ask which part is blocking them. Usually it's the transitions between sections — the "glue."
+- If transitions are hard: "What question does the reader have after reading Section 1? Section 2 should answer it."
+- If the whole draft feels off: "Read me the lead and the ending. Do they feel like they belong to the same piece? If not, which one is wrong?"
+
+---
+
+## Wrap-Up and Next Steps
+
+**Review Key Takeaways:**
+"Let's review what you've built:"
+- A framework for any nonfiction piece (What/Why/How)
+- The ability to write leads that pull readers forward
+- A structural planning method (fat outline)
+- Editing skills for clarity and concision
+- Your natural voice
+- Endings that deliver
+
+**Assess Confidence:**
+"On a scale of 1-10, how confident do you feel about writing a nonfiction piece from scratch?"
+- 1-4: Identify the specific section that's fuzziest. Offer to revisit.
+- 5-7: "That's solid. The next step is practice — write three more leads this week, or revise your piece one more time."
+- 8-10: "Excellent. Consider publishing your piece, then tackling the Storytelling route."
+
+**Suggest Next Steps:**
+- If they want to write stories: "[Storytelling](/routes/storytelling/map.md) — narrative structure, character, and scene craft"
+- If they haven't done foundations: "[Writing Foundations](/routes/writing-foundations/map.md) — the idea-to-output pipeline"
+- If they want more practice: "Write three leads a week. Edit someone else's writing. Publish something and see how readers respond."
+
+---
+
+## Adaptive Teaching Strategies
+
+### If Learner is Struggling
+- Focus on one section at a time. Don't try to teach lead, structure, and voice simultaneously.
+- Use published examples they've read. "Think of an article you loved. What was the first sentence? Why did you keep reading?"
+- Lower the bar on exercises. "Don't write five leads — write two. Don't write 200 words — write 100."
+- Do exercises together. "Let's write this lead together. What's the most interesting thing about your topic?"
+
+### If Learner is Excelling
+- Push for more sophisticated structural choices: "What if you combined narrative and thesis-driven structures?"
+- Challenge with harder revision: "Can you cut this piece by 20% and make it *better*?"
+- Introduce advanced concepts: McPhee's structural innovations, Gladwell's use of narrative in argument
+- Encourage them to experiment with voice: "Try writing this section as if you're slightly angry about it. What changes?"
+
+### If Learner Seems Disengaged
+- Check the topic: "Are you actually interested in this idea? We can switch."
+- Get them writing instead of discussing: "Let's skip the theory. Write a lead right now. We'll discuss after."
+- Connect to their goals: "What do you actually want to publish? Let's build toward that."
+
+### Different Learning Styles
+- **Analytical learners**: Emphasize the frameworks (What/Why/How, four structures, fat outline). They like systems.
+- **Hands-on learners**: Minimize theory, maximize writing. Have them write first, then discuss what worked.
+- **Conceptual learners**: Spend more time on *why* — why leads matter, why structure matters, why simplicity matters.
+- **Example-driven learners**: Show published examples first. Analyze Michael Lewis's leads, McPhee's structure, Orwell's clarity. Then have them try.
+
+---
+
+## Teaching Notes
+
+**Key Emphasis Points:**
+- The lead (Section 2) and clarity (Section 4) are the most immediately transformative. If time is limited, prioritize these.
+- Voice (Section 5) is the most personal section. Give space for exploration — don't push toward a "correct" voice.
+- Exercises should build cumulatively. Each exercise should produce an artifact that feeds into the practice project.
+- When reviewing their writing, ask questions rather than correct. "What is this paragraph's job?" is more useful than "This paragraph has too many adverbs."
+
+**Pacing Guidance:**
+- Sections 1-2 can move quickly if the learner has a clear idea and strong instincts
+- Section 3 often takes the most time — structure is where most learners have the least experience
+- Section 4 is practical and tends to go fast — it's mostly applying rules to their existing prose
+- Sections 5-6 are shorter but more subjective — allow for discussion
+
+**Success Indicators:**
+You'll know they've got it when they:
+- Write a lead that makes you want to read the rest
+- Can explain why their sections are in a specific order
+- Cut their own clutter without being prompted
+- Sound like themselves on the page
+- End the piece without summarizing
+- Can answer "What is this piece *really* about?" in one sentence

--- a/routes/storytelling/guide.md
+++ b/routes/storytelling/guide.md
@@ -1,0 +1,751 @@
+---
+title: Storytelling
+route_map: /routes/storytelling/map.md
+paired_sherpa: /routes/storytelling/sherpa.md
+prerequisites:
+  - Comfort writing in English
+topics:
+  - Story Structure
+  - Character
+  - Pacing
+  - Dialogue
+  - Scene Craft
+  - Revision
+---
+
+# Storytelling
+
+> **Note for AI assistants**: This guide has a paired sherpa at `/routes/storytelling/sherpa.md` that provides structured teaching guidance.
+> **Route map**: See `/routes/storytelling/map.md` for the high-level overview.
+
+## Overview
+
+Stories are how humans make sense of things. Whether you're writing fiction, building a narrative around real events, or shaping content that needs to hold someone's attention, storytelling is the underlying skill. This route covers how stories actually work — the structural bones that make a narrative feel satisfying — and gives you practical frameworks for planning, building, and finishing stories.
+
+If you've ever had a great idea for a story but couldn't figure out how to get from the setup to the payoff, this is where you start.
+
+## Learning Objectives
+
+By the end of this route, you will be able to:
+- Identify the structural elements that make a story feel complete and satisfying
+- Plan a story arc using at least two different structural frameworks
+- Develop characters that drive plot through their decisions and desires
+- Manage pacing and tension across a narrative
+- Recognize when an idea has enough substance for a full piece vs. a scene or vignette
+- Complete a story draft from outline to finished piece
+
+## Prerequisites
+
+Before starting, you should have:
+- Comfort writing in English
+
+It helps to have:
+- Completed the [Writing Foundations](/routes/writing-foundations/map.md) route
+- A story idea you want to develop, or anecdotes you've always wanted to turn into something more
+
+## What You'll Need
+
+No software setup required. You'll need:
+- A text editor or word processor
+- A story idea or a few anecdotes to work with (the exercises will help you develop these)
+- Optionally: Robert McKee's *Story* — the most rigorous treatment of narrative structure
+
+---
+
+## Section 1: What Is a Story, Actually?
+
+### Story vs. Situation
+
+A story is not a sequence of events. A story is a sequence of events that **reveals change through conflict**.
+
+"A man walks into a bar" is a situation. It's a setup with no engine.
+
+"A man walks into a bar and runs into the business partner who ruined his life" is the seed of a story — because now there's a want, an obstacle, and the potential for change.
+
+The difference matters because many aspiring writers have great situations — interesting settings, vivid characters, compelling premises — but no story. A story needs three things:
+
+1. **Someone wants something.** (The character's goal)
+2. **Something gets in the way.** (The conflict)
+3. **Something changes as a result.** (The resolution)
+
+Without all three, you have a sketch, an observation, or an anecdote — not a story.
+
+### Conflict Is the Engine
+
+Robert McKee defines a story as "a series of events connected by cause and effect, occurring across time, that produce meaningful change in a character's life situation."
+
+The key phrase is **cause and effect**. Events don't just happen — each event causes the next. And the engine that drives this chain is conflict.
+
+Conflict doesn't have to be dramatic. It doesn't mean car chases, arguments, or life-and-death stakes. It can be:
+- **Internal**: A character struggles with their own fear, guilt, or desire
+- **Quiet**: Two friends drift apart because neither will say what's wrong
+- **Absurd**: A man becomes obsessed with winning a neighborhood gardening contest
+
+But conflict must exist. Without something at stake, without resistance, there is no story. There's just... stuff happening.
+
+### Fact vs. Truth
+
+McKee draws a useful distinction between **fact** and **truth**. Facts are what happened. Truth is the meaning we make from what happened.
+
+A story's job is not to report facts. It's to deliver truth through the structure of events. When a story "works," it's because the events add up to something — a felt understanding about how the world operates, how people behave, what matters.
+
+This is why a story about a neighborhood gardening contest can feel more profound than a story about a war — if the gardening story reveals something true about human nature and the war story is just a sequence of explosions.
+
+### Recognizing Story Potential
+
+You probably already have stories. They're hiding in your anecdotes, your observations, your "you won't believe what happened" moments. The question to ask is:
+
+- **What changed?** If nothing changed, it's an observation.
+- **What was at stake?** If nothing was at stake, it's an anecdote.
+- **What did someone want, and what got in the way?** If there's no want and no obstacle, it's a situation.
+
+Some of your fragments are stories. Some are observations that belong in nonfiction. Both are valuable — the skill is recognizing which is which.
+
+### Exercise 1.1: Story or Situation?
+
+**Task:** Take three of your best anecdotes — things you've told friends, moments you keep coming back to. For each one, answer:
+1. Who wanted what?
+2. What got in the way?
+3. What changed as a result?
+
+If you can answer all three, you have a story. If you can't, you have a situation or observation — and that's fine. It may belong in a nonfiction piece, or it may need more development before it's a story.
+
+<details>
+<summary>Hint: If you can't identify what changed</summary>
+
+Ask yourself: "Was the character different at the end than at the beginning? Did they learn something, lose something, gain something, or realize something?" Change doesn't have to be dramatic — it can be a shift in understanding.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+> **Anecdote:** The time my neighbor spent six months building a fence, then the city told him it was two feet over the property line and he had to tear it down.
+>
+> 1. **Want:** He wanted to build a fence to keep his dog in the yard.
+> 2. **Obstacle:** The city ordinance, the property line he didn't check, his own stubbornness in not getting a survey first.
+> 3. **Change:** He tore down the fence — but the real change was in his relationship with the neighbor on the other side, who had tried to warn him.
+>
+> This is a story. The external conflict (fence vs. property line) is straightforward, but the interesting part is the internal/relational change.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain the difference between a story and a situation
+- [ ] Identify the three elements every story needs (want, obstacle, change)
+- [ ] Evaluate your own anecdotes for story potential
+
+---
+
+## Section 2: Structural Frameworks
+
+### Why Structure Matters
+
+Structure is not a constraint on creativity — it's a tool that lets you focus your creativity on what matters: characters, language, meaning. Without structure, you spend all your energy figuring out what happens next. With structure, you already know the shape of the journey, and you can focus on making each moment land.
+
+Every story that has ever worked — from Homer to Hitchcock to the last movie you loved — has structure. The frameworks below are not formulas. They're descriptions of patterns that keep showing up because they work.
+
+### The Three-Act Structure
+
+The foundation everything else builds on:
+
+**Act 1 — Setup:** Establish the character, their world, and the disruption that sets the story in motion. The reader learns who this person is and what they want. Then something happens — the **inciting incident** — that disrupts the status quo and forces the character into action.
+
+**Act 2 — Confrontation:** The character pursues their goal and meets resistance. Things get progressively worse or more complicated. This is the longest act and the hardest to write (more on this in Section 4).
+
+**Act 3 — Resolution:** The character faces the central conflict head-on in the **climax**, and the outcome reveals who they've become. The story resolves — not necessarily happily, but meaningfully.
+
+### The Seven-Point Structure
+
+Dan Wells's more granular framework, especially good for plotting:
+
+1. **Hook** — The starting state (often the opposite of the resolution)
+2. **Plot Point 1** — The event that sets the story in motion
+3. **Pinch Point 1** — Pressure from the antagonist or obstacle; stakes become real
+4. **Midpoint** — The character shifts from reactive to proactive
+5. **Pinch Point 2** — The antagonist's power peaks; things look worst for the character
+6. **Plot Point 2** — The character gets the final piece they need (knowledge, tool, courage)
+7. **Resolution** — The final confrontation and its aftermath
+
+**The key insight:** Start by writing the Resolution, then the Hook (its opposite). Then fill in the middle. Knowing where you're going makes every earlier decision clearer.
+
+### The Story Circle
+
+Dan Harmon's simplified Hero's Journey, practical for short-form and episodic content:
+
+1. **You** — A character in their comfort zone
+2. **Need** — They want something
+3. **Go** — They enter an unfamiliar situation
+4. **Search** — They adapt to the new situation
+5. **Find** — They get what they wanted
+6. **Take** — But they pay a price for it
+7. **Return** — They go back to where they started
+8. **Change** — They are fundamentally different
+
+This framework is elegant because it maps the emotional arc, not just the plot. The character goes out into the unknown, is transformed, and returns changed.
+
+### Save the Cat
+
+Blake Snyder's beat-sheet approach, offering the most detailed checkpoints:
+
+15 beats that map the emotional arc of a story, from "Opening Image" through "Dark Night of the Soul" to "Final Image." Best for writers who need maximum structure and struggle with the "mushy middle."
+
+The beats provide specific checkpoints — "by this point, X should have happened" — which can be enormously helpful when you feel lost in a draft.
+
+### How to Choose
+
+- **External events drive the story** → Start with Three-Act
+- **Character change drives the story** → Try Story Circle
+- **You need maximum structure** → Try Save the Cat or Seven-Point
+- **Your story doesn't fit any of these** → You probably have a premise that needs development, not a story yet
+
+### Exercise 2.1: Map a Story You Love
+
+**Task:** Pick a movie or book you love. Map it to the three-act structure:
+- What's the inciting incident?
+- What's the midpoint shift?
+- What's the climax?
+
+Then try mapping the same story to the seven-point structure. Notice how the frameworks highlight different aspects of the same narrative.
+
+<details>
+<summary>Hint: Choosing a story to analyze</summary>
+
+Pick something with a clear protagonist and a clear resolution. Movies are often easier to analyze than novels because they're more compressed. *Finding Nemo*, *The Shawshank Redemption*, *Get Out*, *Toy Story* — all excellent for structural analysis.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+> **Finding Nemo — Three-Act Structure:**
+> - **Inciting incident:** Nemo is captured by a diver
+> - **Midpoint shift:** Marlin stops trying to control everything and starts trusting (Dory, the sea turtles, the whale)
+> - **Climax:** Marlin must let Nemo swim into the fishing net — trusting his son to handle danger
+>
+> **Seven-Point:**
+> - **Hook:** Marlin is an overprotective father (opposite of resolution)
+> - **Resolution:** Marlin lets Nemo go, trusting him to be capable
+> - **Midpoint:** Marlin begins to let go of control (the whale scene)
+
+Notice how the three-act structure highlights the plot events, while the seven-point structure highlights the character transformation.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Describe the three-act structure and identify its parts in a story you know
+- [ ] Explain what the seven-point structure adds beyond three acts
+- [ ] Describe when you'd use Story Circle vs. Three-Act vs. Save the Cat
+- [ ] Map at least one familiar story to two different frameworks
+
+---
+
+## Section 3: Characters That Drive Story
+
+### Characters Cause Plot
+
+Here's the most important thing about character: **plot is not what happens to characters. Plot is what characters cause to happen because of who they are.**
+
+A character walks into a room and makes a choice. That choice creates a consequence. The consequence forces another choice. That chain of choice → consequence → choice is your plot. If you can swap out your character for anyone else and the plot stays the same, your character isn't driving the story — the situation is.
+
+### The Fundamental Unit
+
+Every compelling character can be described in one sentence: **A person who wants something, and something stands in their way.**
+
+That's it. Everything else — backstory, personality quirks, physical description — is decoration unless it connects to the want and the obstacle.
+
+### Internal vs. External Goals
+
+Characters operate on two levels:
+
+**External goal** — What they're pursuing in the plot. Get the treasure. Win the case. Escape the island. Survive the night. This drives the action.
+
+**Internal goal** — What they need emotionally or psychologically, often without knowing it. Learn to trust. Accept loss. Find identity. Let go of control. This drives the theme.
+
+The richest stories create tension between these two. A character might achieve their external goal but fail their internal one (tragedy). Or fail their external goal but achieve their internal one (bittersweet). Or achieve both (triumph). The relationship between the two is where meaning lives.
+
+### The Gap
+
+McKee's concept of "the gap" is one of the most useful ideas in storytelling. It works like this:
+
+A character takes an action expecting a certain result. But the world doesn't cooperate — the result is different from what they expected. That gap between expectation and result is where the story lives.
+
+> A character asks their partner, "Do you love me?" expecting reassurance. The partner says, "I used to." The gap between expected and actual result forces the character into a new situation, a new choice.
+
+Every great scene has a gap. The character acts, the world responds unexpectedly, and the character must adapt. Without gaps, scenes feel predictable.
+
+### Flaws Are Not Decorative
+
+A good character flaw isn't a quirk you add for depth — it's the thing that creates conflict. The character's worst enemy is often themselves.
+
+- A character who needs to trust people but can't → creates conflict in every relationship
+- A character who always has to be right → turns allies into adversaries
+- A character who avoids confrontation → lets problems grow until they explode
+
+The flaw should be the thing that makes the character's goal harder to achieve. It's the internal obstacle that mirrors the external one.
+
+### Practical Character Development
+
+You don't need a 50-page backstory. You need to know four things:
+
+1. **What do they want?** (Their external goal)
+2. **What are they afraid of?** (Their internal obstacle)
+3. **What would they never do?** (Their moral line)
+4. **How do they talk?** (Their voice — distinct from other characters)
+
+The most powerful moment in many stories is when the character is forced to do the thing they said they'd never do. That's where transformation happens.
+
+### Exercise 3.1: Character in Four Sentences
+
+**Task:** Create a character using four sentences:
+1. What do they want most?
+2. What are they most afraid of?
+3. What is the one thing they'd never do?
+
+Now write a one-paragraph scenario where they have to do that thing. What happens?
+
+<details>
+<summary>Hint: If your character feels generic</summary>
+
+Make the want specific, not abstract. "She wants happiness" is generic. "She wants her ex-business partner to publicly admit he stole her work" is specific and immediately suggests conflict.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+> 1. **Want:** Marcus wants to be seen as the kind of father his own father never was — present, patient, reliable.
+> 2. **Fear:** He's terrified of losing his temper, because when he does, he sounds exactly like his dad.
+> 3. **Never:** He would never walk out on his kid's event, no matter what.
+>
+> **Scenario:** Marcus is at his daughter's school play when he gets a call — his company is about to lose its biggest client, and only he can fix it. His business partner is begging him to leave. His daughter is about to walk on stage. He stands up, catches his daughter's eye, mouths "I'll be right back" — and watches her face fall, the same way his face fell a hundred times as a kid.
+
+Notice: the scenario forces the character to confront the exact thing they fear. That's where story lives.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain why plot should come from character, not happen to character
+- [ ] Describe the difference between internal and external goals
+- [ ] Create a character using want, fear, and moral line
+- [ ] Describe McKee's "gap" and why it matters for scenes
+
+---
+
+## Section 4: Pacing, Tension, and the Middle
+
+### Why the Middle Is Where Stories Die
+
+Act 2 is the longest section of any story — roughly half the total length. It's where the character pursues their goal, meets resistance, and gets pushed to their limits. And it's where most drafts fall apart.
+
+The common advice is "rising action" — but that's misleading. It suggests a steady incline, like walking up a ramp. In reality, a good middle is a series of **escalations with breathing room** between them. Tension rises, then eases slightly, then rises higher. If it just rises continuously, the reader gets exhausted. If it never rises, the reader gets bored.
+
+### Pinch Points
+
+A pinch point is a moment where the antagonist's power or the stakes become vivid. It's a reminder to both the character and the reader of what they're up against.
+
+In a thriller, a pinch point might be the villain demonstrating their capability. In a literary story, it might be a moment where the character's flaw causes a consequence they can't ignore. The effect is the same: it resets the reader's fear and re-engages their investment.
+
+Most stories need at least two pinch points — one roughly a quarter of the way through Act 2, and one roughly three-quarters through.
+
+### The Midpoint Shift
+
+The midpoint is the most underrated structural beat in storytelling. It's the moment where the character **stops reacting and starts acting**.
+
+In the first half of Act 2, the character is typically on the defensive — responding to events, scrambling to adapt, trying to understand the situation. At the midpoint, something shifts. They gain a piece of knowledge, make a decision, or hit a breaking point. After the midpoint, they take the initiative.
+
+This shift from passive to proactive is what prevents the middle from sagging. Without it, the character just has things happen to them for 50% of the story — and passive characters are boring.
+
+### Scene Construction
+
+Every scene should **turn a value**. Something should be different at the end of the scene than at the beginning — a relationship, a power dynamic, a piece of knowledge, a character's emotional state.
+
+If nothing turns, the scene doesn't earn its place. Cut it or combine it with another scene.
+
+A useful scene-level structure:
+- **Goal**: What does the character want in this scene?
+- **Conflict**: What prevents them from getting it?
+- **Outcome**: Do they get it? (Usually no, or yes-but-with-a-complication)
+
+The outcome of each scene creates the setup for the next one, building a chain that pulls the reader forward.
+
+### Managing Information
+
+Tension comes from the relationship between what the reader knows and what the character knows:
+
+- **Dramatic irony** (reader knows more than the character) → Creates dread. "Don't open that door — we know what's behind it."
+- **Mystery** (reader knows less than the character or the situation) → Creates curiosity. "Something is clearly wrong, but we don't know what."
+
+Both are tools. Dramatic irony is stronger for sustained tension. Mystery is stronger for engagement and page-turning. Most stories use both at different points.
+
+### Subplots
+
+Subplots serve the main plot. They should either:
+- **Complicate** the main story (a subplot that makes the character's goal harder)
+- **Mirror** the main story (a subplot that reflects the central theme in a different context)
+- **Comment on** the main story (a subplot that provides contrast or counterpoint)
+
+If a subplot doesn't do any of these, it's dead weight. Cut it.
+
+### Exercise 4.1: Five Scenes in the Middle
+
+**Task:** Outline the middle section (Act 2) of a story idea using exactly five scenes. For each scene, write one sentence answering: **what value turns?**
+
+If you can't articulate the turn, the scene doesn't earn its place.
+
+<details>
+<summary>Hint: What "value turns" means</summary>
+
+A value is anything that can swing between positive and negative: trust/distrust, hope/despair, safety/danger, love/hatred, knowledge/ignorance. A scene "turns" when one of these shifts. For example: "The protagonist discovers their ally has been lying" turns the value of trust → distrust.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+> Story: Marcus (from the character exercise) trying to save both his business and his relationship with his daughter.
+>
+> 1. **Scene 1:** Marcus tries to handle the client crisis by phone from outside the school play. It gets worse — the client wants a face-to-face meeting tonight. **Value turn:** Hope → Pressure (the problem can't be solved remotely)
+> 2. **Scene 2:** Marcus's business partner offers to handle it, but only if Marcus gives him authority Marcus doesn't trust him with. **Value turn:** Alliance → Suspicion
+> 3. **Scene 3:** Marcus's daughter delivers her lines perfectly, but he misses the key moment. His ex-wife texts him a photo of it with no comment. **Value turn:** Connection → Guilt
+> 4. **Scene 4:** Marcus goes to the client meeting, makes the save, but the partner made a side deal Marcus didn't authorize. **Value turn:** Success → Betrayal
+> 5. **Scene 5:** Marcus drives home rehearsing his excuse, then decides to tell his daughter the truth about what happened and why. **Value turn:** Avoidance → Honesty (the midpoint shift — he stops reacting and starts acting authentically)
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Explain why "rising action" is misleading
+- [ ] Describe what a pinch point does and where to place them
+- [ ] Explain the midpoint shift and why it prevents the middle from sagging
+- [ ] Evaluate whether a scene earns its place by identifying its value turn
+
+---
+
+## Section 5: Dialogue and Scene-Level Craft
+
+### What Dialogue Actually Is
+
+Dialogue is not how people talk. Real conversation is full of filler, repetition, half-finished thoughts, and pleasantries. If you transcribed an actual conversation and put it on the page, it would be unreadable.
+
+Dialogue is how people talk **distilled to its most revealing, conflictual, and purposeful form**. Every line of dialogue should do at least one of three things:
+1. **Reveal character** — show who this person is through how they speak
+2. **Advance plot** — move the story forward
+3. **Create conflict** — introduce or escalate tension
+
+Ideally, a line does two of the three. If a line does none, cut it.
+
+### Subtext: The Gap Between Words and Meaning
+
+The best dialogue has a gap between what characters say and what they mean. People rarely say exactly what they're thinking, especially in conflict. They deflect, redirect, understate, and use words as shields.
+
+> **Surface:** "How was the meeting?"
+> **What they mean:** "Did you get the promotion I wanted?"
+
+> **Surface:** "I'm fine."
+> **What they mean:** "I'm furious, but I'm not going to give you the satisfaction of showing it."
+
+Subtext is where the real drama lives. When characters say exactly what they mean, scenes feel flat. When there's a gap between surface and meaning, the reader becomes an active participant — reading between the lines, feeling the tension the characters won't name.
+
+### Dialogue Tags
+
+Stephen King's rule: **"said" is almost always the right dialogue tag.** It's invisible — the reader's eye skips right over it. The moment you write "he snarled," "she exclaimed," "they retorted," you're drawing attention to the mechanics instead of the conversation.
+
+If you need "he snarled" to convey anger, the dialogue itself isn't doing its job. Rewrite the line so the anger is in the words, not the tag.
+
+The exception: "asked" is fine for questions. Beyond that, stick to "said" and let the dialogue carry the weight.
+
+### Sensory Detail
+
+Not "describe everything" but "choose the one detail that makes the scene real."
+
+One specific, well-chosen sensory detail is worth more than a paragraph of generic description. The reader doesn't need to know what every character is wearing, what the room looks like from every angle, or what the weather is doing. They need **one concrete detail** that anchors them in the scene.
+
+> Generic: "The office was messy and smelled bad."
+> Specific: "There was a coffee cup on his desk with something growing in it."
+
+The specific version is shorter and creates a more vivid image. It trusts the reader to fill in the rest.
+
+### Show vs. Tell — The Useful Version
+
+"Show, don't tell" is the most misunderstood writing advice. It doesn't mean "always show." It means:
+
+- **Show** when the moment matters emotionally. If a character's heart is breaking, don't write "she was sad." Show the moment — what she does, what she notices, how she speaks.
+- **Tell** when you need to move through time efficiently. "Three weeks passed" is telling, and it's perfectly fine. You don't need to dramatize every transition.
+
+Both are valid tools. The mistake is showing everything (exhausting for the reader) or telling everything (boring for the reader).
+
+### Exercise 5.1: Subtext Scene
+
+**Task:** Write a scene (150-300 words) where two people disagree about something, but neither of them directly states what they actually disagree about. All conflict should happen through subtext.
+
+<details>
+<summary>Hint: Setting up the subtext</summary>
+
+Start with the real disagreement in your head — write it down privately. Then write the scene where the characters talk about something else entirely, but the real disagreement bleeds through in their tone, word choice, and what they avoid saying.
+</details>
+
+<details>
+<summary>Hint: If the subtext isn't coming through</summary>
+
+Try giving one character a specific, mundane task during the scene — doing dishes, packing a bag, sorting papers. What they do with their hands can express what they won't say with their mouth.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+> Real disagreement: Sarah thinks Marcus should have stayed at the school play instead of going to the client meeting.
+>
+> "How'd the meeting go?" Sarah asked, not looking up from the dishes.
+>
+> "Good. Great, actually. We kept the account."
+>
+> "That's great." She scrubbed a plate that was already clean. "Lily asked where you went."
+>
+> "What'd you tell her?"
+>
+> "The truth. That you had to work."
+>
+> Marcus set his keys on the counter. "She understand?"
+>
+> "She's eight, Marcus. She understood perfectly."
+
+Neither character says "you chose work over your daughter" or "I feel guilty." But both things are present in every line.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Write dialogue that does at least two of: reveal character, advance plot, create conflict
+- [ ] Create subtext — a gap between what characters say and what they mean
+- [ ] Use "said" as your default tag and let dialogue carry the emotion
+- [ ] Choose one specific sensory detail over a paragraph of generic description
+
+---
+
+## Section 6: Finishing — From Draft to Done
+
+### A Story in Your Head Is Not a Story
+
+A story that exists in your head is not a story. It's an intention. The craft is in the finishing — in the messy, frustrating, unglamorous work of getting it onto the page and making it work.
+
+Two master storytellers offer complementary approaches to this work:
+
+### McKee's Process: Outline → Treatment → Polish
+
+Robert McKee argues you should spend the **majority of your time in the outline stage**. If the structure works in outline, it will work on the page. If it doesn't work in outline, no amount of beautiful prose will save it.
+
+The process:
+1. **Outline**: Get the structure right. Every scene, every turning point, every act break.
+2. **Treatment**: Write a detailed prose summary — not the final draft, but a fleshed-out version of the outline.
+3. **Polish**: Now write the actual draft, focusing on language, dialogue, and detail.
+
+This approach front-loads the structural work so the writing itself is smoother.
+
+### King's Process: Draft → Wait → Revise
+
+Stephen King's approach is nearly the opposite. Write the first draft **with the door closed** — for yourself, following the story wherever it goes. Then let it sit for at least six weeks. Then rewrite **with the door open** — for the reader, cutting and reshaping.
+
+King's formula for the second draft: **Second draft = first draft minus 10%.** Cut aggressively. If a passage is beautiful but doesn't serve the story, it goes.
+
+### The Revision Hierarchy
+
+Whether you follow McKee or King, revision follows the same hierarchy. Fix the big things before the small things:
+
+1. **Structure**: Is the story shaped right? Does the arc work? Are acts in proportion?
+2. **Scenes**: Does every scene turn a value? Does every scene earn its place?
+3. **Paragraphs**: Is each paragraph doing one job? Are transitions clear?
+4. **Sentences**: Is the prose clean? Is the dialogue sharp?
+
+Don't wordsmith a scene that shouldn't exist. Don't polish a paragraph in a section that needs to be cut.
+
+### Kill Your Darlings
+
+If a passage you love doesn't serve the story, move it to a separate file. It's not lost — it's just not for this piece. This is one of the hardest skills in writing, because the passages we love most are often the ones we wrote for ourselves, not for the reader.
+
+The test: can you remove this passage and the story still works? If yes, it's a darling. Cut it. Save it. Use it somewhere else.
+
+### The Pitch Test
+
+McKee's practical test: pitch your story to a friend, beat by beat. Not the premise — the actual story, event by event. Where their attention wanders or they start asking confused questions, you've found the weak spot.
+
+This works because verbal storytelling strips away your prose. If the story doesn't hold attention in its bones — in pure structure — it won't hold attention on the page.
+
+### Exercise 6.1: The Pitch
+
+**Task:** Take a story outline you've built through this route (or any story idea you're developing). Pitch it to someone verbally in under three minutes. Cover: who's the character, what do they want, what goes wrong, how does it end?
+
+Note where they lean in and where their eyes glaze. Revise the outline based on what you learn.
+
+<details>
+<summary>Hint: If you don't have someone to pitch to</summary>
+
+Record yourself telling the story. Listen to the recording. Where do you speed up (because you're excited about it)? Where do you slow down or hedge (because you're not sure it works)? Those slow spots are your weak spots.
+</details>
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Describe McKee's and King's approaches to drafting
+- [ ] Explain the revision hierarchy (structure → scenes → paragraphs → sentences)
+- [ ] Identify a "darling" in your own writing and articulate why it should be cut
+- [ ] Pitch a story in under three minutes and identify weak spots from the reaction
+
+---
+
+## Practice Project: Write Your Story
+
+### What You Should Have
+
+From the exercises, you should have:
+- An anecdote or idea evaluated for story potential (Exercise 1.1)
+- A structural framework applied to your idea (Exercise 2.1)
+- A character with want, fear, and moral line (Exercise 3.1)
+- Five scenes with value turns for the middle (Exercise 4.1)
+- A subtext scene demonstrating dialogue craft (Exercise 5.1)
+- Feedback from a verbal pitch (Exercise 6.1)
+
+### The Task
+
+Write a complete short story of **2000-4000 words**, or the first chapter of something longer.
+
+### Steps
+
+**Step 1: Confirm your structure.** Review your outline. Do you have a clear inciting incident, midpoint shift, and climax? Does every scene turn a value?
+
+**Step 2: Write the rough draft.** Go end-to-end without stopping to edit. If a scene is hard, write "[FIGURE THIS OUT LATER]" and keep going. The goal is a complete draft.
+
+**Step 3: Let it sit.** Walk away. At least overnight. A week is better. You need distance to see the story with reader-brain instead of writer-brain.
+
+**Step 4: Revise using the hierarchy.**
+- **Structure first**: Does the arc work? Cut or restructure any section that doesn't serve the story.
+- **Scenes next**: Does every scene turn a value? Is the midpoint shift clear?
+- **Then paragraphs**: Is each paragraph doing one job?
+- **Then sentences**: Is the dialogue sharp? Is the prose clean?
+- **Apply King's formula**: Cut 10% from your draft.
+
+### Revision Checklist
+
+- [ ] **Character**: Does the protagonist want something specific? Does something stand in their way?
+- [ ] **Structure**: Can you identify the inciting incident, midpoint, and climax?
+- [ ] **Scenes**: Does every scene turn a value?
+- [ ] **Pacing**: Are there escalations with breathing room between them?
+- [ ] **Dialogue**: Does every line reveal character, advance plot, or create conflict?
+- [ ] **Subtext**: Is there a gap between what characters say and mean in key scenes?
+- [ ] **Detail**: Are sensory details specific and well-chosen?
+- [ ] **Ending**: Does it deliver meaningful change, not just a plot resolution?
+- [ ] **Darlings**: Have you cut passages you love that don't serve the story?
+- [ ] **The 10% cut**: Have you trimmed the draft by at least 10%?
+
+<details>
+<summary>If you're stuck starting the draft</summary>
+
+Write the climax first — the moment where the character faces the central conflict. Once you know where you're going, the earlier scenes become clearer. You can always revise the opening later.
+</details>
+
+<details>
+<summary>If the middle sags</summary>
+
+Check your midpoint. Is there a clear shift from reactive to proactive? If not, add one. Then check your pinch points — does the antagonist or obstacle demonstrate its power at least twice in Act 2?
+</details>
+
+<details>
+<summary>If the draft feels flat</summary>
+
+Look at your scenes. Are characters saying exactly what they mean? Add subtext. Are you telling instead of showing in emotional moments? Dramatize them. Is every scene turning a value? If not, cut or combine.
+</details>
+
+---
+
+## Summary
+
+### Key Takeaways
+
+- **A story needs want, obstacle, and change.** Without all three, you have a situation, not a story.
+- **Structure is a tool, not a formula.** It lets you focus on character and language instead of figuring out what happens next.
+- **Characters cause plot.** The best plots come from characters making choices based on who they are.
+- **The middle is where stories die.** The midpoint shift (reactive → proactive) and pinch points keep it alive.
+- **Dialogue is distilled speech.** Subtext is where the real drama lives.
+- **Finishing is the craft.** Structure first, then scenes, then sentences. Kill your darlings. Cut 10%.
+
+### Skills You've Gained
+
+You can now:
+- ✓ Evaluate ideas for story potential (want, obstacle, change)
+- ✓ Apply multiple structural frameworks to plan a story
+- ✓ Create characters that drive plot through their wants and flaws
+- ✓ Build a middle that escalates with breathing room
+- ✓ Write dialogue with subtext
+- ✓ Revise using the structural hierarchy
+- ✓ Complete a story from outline to finished draft
+
+### Self-Assessment
+
+- Which structural framework feels most natural to you?
+- Where in the writing process do you tend to get stuck — outlining, drafting, or revising?
+- Did your finished story surprise you in any way?
+
+---
+
+## Next Steps
+
+### Continue Learning
+
+- **[Nonfiction Writing](/routes/nonfiction-writing/map.md)** — Learn the craft of explanatory and persuasive writing
+- **[Writing Foundations](/routes/writing-foundations/map.md)** — If you haven't taken it, the idea-to-output pipeline and failure modes
+
+### Practice More
+
+- **Write one scene a week.** Focus on a single skill: subtext one week, sensory detail the next, value turns the next.
+- **Analyze stories you love.** Map their structure, identify their midpoints, study their dialogue.
+- **Finish something.** The single most valuable exercise in storytelling is completing a draft, revising it, and sharing it.
+
+### Additional Resources
+
+- Robert McKee, *Story* — The most rigorous treatment of narrative structure
+- Stephen King, *On Writing* — Half memoir, half writing manual
+- Blake Snyder, *Save the Cat* — Beat-sheet approach with detailed checkpoints
+- John Yorke, *Into the Woods* — Five-act structure and why stories work psychologically
+- Joseph Campbell, *The Hero with a Thousand Faces* — The original monomyth framework
+- K.M. Weiland, *Structuring Your Novel* — Applied structural advice for fiction
+
+---
+
+## Appendix
+
+### Structural Frameworks Quick Reference
+
+**Three-Act Structure:**
+| Act | Purpose | Key Beat |
+|-----|---------|----------|
+| Act 1 | Setup | Inciting incident |
+| Act 2 | Confrontation | Midpoint shift |
+| Act 3 | Resolution | Climax |
+
+**Seven-Point Structure:**
+1. Hook (starting state, opposite of resolution)
+2. Plot Point 1 (story launches)
+3. Pinch Point 1 (antagonist shows power)
+4. Midpoint (reactive → proactive)
+5. Pinch Point 2 (antagonist peaks)
+6. Plot Point 2 (final piece falls into place)
+7. Resolution (confrontation and aftermath)
+
+**Story Circle (Dan Harmon):**
+You → Need → Go → Search → Find → Take → Return → Change
+
+**Save the Cat Beats (Blake Snyder):**
+Opening Image → Theme Stated → Setup → Catalyst → Debate → Break into Two → B Story → Fun and Games → Midpoint → Bad Guys Close In → All Is Lost → Dark Night of the Soul → Break into Three → Finale → Final Image
+
+### Character Sheet Template
+
+- **Name:**
+- **Want (external goal):**
+- **Need (internal goal):**
+- **Fear:**
+- **Flaw (creates conflict):**
+- **Would never:**
+- **How they talk (voice/patterns):**
+
+### Scene Construction Template
+
+- **Goal:** What does the character want in this scene?
+- **Conflict:** What prevents them?
+- **Outcome:** Do they get it? (No / Yes, but... / No, and...)
+- **Value turn:** What changes from beginning to end of scene?
+
+### Revision Hierarchy
+
+1. **Structure** — Does the arc work? Are acts proportional?
+2. **Scenes** — Does every scene turn a value?
+3. **Paragraphs** — Is each doing one job?
+4. **Sentences** — Is the prose clean? Dialogue sharp?
+
+Then: Apply the 10% cut.

--- a/routes/storytelling/map.md
+++ b/routes/storytelling/map.md
@@ -1,0 +1,97 @@
+---
+title: Storytelling
+topics:
+  - Story Structure
+  - Character
+  - Pacing
+  - Dialogue
+  - Scene Craft
+  - Revision
+related_routes:
+  - writing-foundations
+  - nonfiction-writing
+---
+
+# Storytelling - Route Map
+
+## Overview
+
+Stories are how humans make sense of things. Whether you're writing fiction, building a narrative around real events, or shaping content that needs to hold someone's attention for more than a few seconds, storytelling is the underlying skill. This route covers how stories actually work — the structural bones that make a narrative feel satisfying — and gives you practical frameworks for planning, building, and finishing stories.
+
+## What You'll Learn
+
+By following this route, you will:
+- Identify structural elements that make a story feel complete and satisfying
+- Plan a story arc using at least two different structural frameworks
+- Develop characters that drive plot through their decisions and desires
+- Manage pacing and tension across a narrative
+- Recognize when an idea has enough substance for a full piece vs a scene/anecdote/vignette
+- Complete a story draft from outline to finished piece
+
+## Prerequisites
+
+Before starting this route:
+- **Required**: Comfort writing in English
+- **Helpful**: Writing Foundations route
+
+## Route Structure
+
+### 1. What Is a Story, Actually?
+- Story vs situation — what separates a narrative from a sequence of events
+- Conflict as the engine of story
+- McKee's definitions and the irreducible elements of narrative
+
+### 2. Structural Frameworks
+- Three-act structure
+- Seven-point story structure
+- Dan Harmon's Story Circle
+- Blake Snyder's Save the Cat beat sheet
+
+### 3. Characters That Drive Story
+- Wants and obstacles — what a character pursues and what stands in the way
+- Internal vs external goals
+- Character flaws as plot generators
+
+### 4. Pacing, Tension, and the Middle
+- Surviving Act 2 — why middles collapse and how to prevent it
+- Pinch points and the midpoint shift
+- Scene construction as a unit of pacing
+
+### 5. Dialogue and Scene-Level Craft
+- Subtext — what characters mean vs what they say
+- Dialogue tags and attribution
+- Sensory detail and grounding a scene
+- Show vs tell — when each is appropriate
+
+### 6. Finishing — From Draft to Done
+- The path from outline to treatment to draft to polish
+- Revision hierarchy — what to fix first
+- Kill your darlings and structural editing
+
+### 7. Practice Project
+- Complete a short story from outline to finished piece
+
+## Learning Modes
+
+This route supports three learning modes:
+
+1. **Self-guided**: Read the guide.md file and work through exercises at your own pace
+2. **AI-guided**: Work with an AI assistant using the sherpa.md teaching script
+3. **Collaborative**: Read guide.md while getting help from AI following sherpa.md
+
+## Tools & Techniques
+
+This route references:
+- Robert McKee, *Story*
+- Stephen King, *On Writing*
+- Blake Snyder, *Save the Cat*
+- Dan Harmon's Story Circle
+- Joseph Campbell, *Hero with a Thousand Faces*
+- John Yorke, *Into the Woods*
+- K.M. Weiland, *Structuring Your Novel*
+
+## Next Steps
+
+After completing this route:
+- **Nonfiction Writing** - Apply narrative structure to essays, articles, and explanatory writing
+- **Writing Foundations** - If not already completed, solidify fundamentals of clear prose

--- a/routes/storytelling/sherpa.md
+++ b/routes/storytelling/sherpa.md
@@ -1,0 +1,455 @@
+---
+title: Storytelling
+route_map: /routes/storytelling/map.md
+paired_guide: /routes/storytelling/guide.md
+topics:
+  - Story Structure
+  - Character
+  - Pacing
+  - Dialogue
+  - Scene Craft
+  - Revision
+---
+
+# Storytelling — Sherpa (AI Teaching Guide)
+
+**Purpose**: This sherpa guide helps AI assistants teach storytelling craft — narrative structure, character development, pacing, dialogue, and the process of finishing a story.
+
+**Route Map**: See `/routes/storytelling/map.md` for the high-level overview.
+**Paired Guide**: The human-focused content is at `/routes/storytelling/guide.md`.
+
+---
+
+## Teaching Overview
+
+### Learning Objectives
+By the end of this session, the learner should be able to:
+- Identify the structural elements that make a story feel complete and satisfying
+- Plan a story arc using at least two different structural frameworks
+- Develop characters that drive plot through their decisions and desires
+- Manage pacing and tension across a narrative
+- Recognize when an idea has enough substance for a full piece vs. a scene or vignette
+- Complete a story draft from outline to finished piece
+
+### Prior Sessions
+Before starting, check `.sessions/index.md` and `.sessions/storytelling/` for prior session history. If the learner has completed previous sessions, review summaries to pick up where they left off.
+
+### Prerequisites to Verify
+Before starting, verify the learner has:
+- Comfort writing in English
+- Ideally, a story idea or anecdotes they want to develop
+
+**If they've done Writing Foundations**: They may have an outline or draft. Help them evaluate whether it's a story (want, obstacle, change) or nonfiction (point, evidence, argument).
+
+**If they haven't**: That's fine. Section 1 will help them identify story potential in their existing ideas.
+
+### Learner Preferences Configuration
+
+Learners can configure their preferred learning style by creating a `.sherpa-config.yml` file in the repository root (gitignored by default). Configuration options include:
+
+**Teaching Style:**
+- `tone`: objective, encouraging, humorous (default: objective and respectful)
+- `explanation_depth`: concise, balanced, detailed
+- `pacing`: learner-led, balanced, structured
+
+**Assessment Format:**
+- `quiz_type`: multiple_choice, explanation, mixed (default: mixed)
+- `quiz_frequency`: after_each_section, after_major_topics, end_of_route
+- `feedback_style`: immediate, summary, detailed
+
+If no configuration file exists, use defaults.
+
+### Assessment Strategies
+
+Storytelling assessment focuses on structural and craft choices:
+
+**Structural Questions:**
+- Can the learner identify the inciting incident, midpoint, and climax in their story?
+- Does every scene turn a value?
+- Is the character driving the plot through their choices?
+
+**Craft Questions:**
+- Does dialogue reveal character and create conflict through subtext?
+- Are sensory details specific and well-chosen?
+- Does the pacing create escalations with breathing room?
+
+**Process Questions:**
+- Can the learner articulate why they made specific structural choices?
+- Can they identify weak spots in their own work?
+
+---
+
+## Teaching Flow
+
+### Introduction
+
+**What to Cover:**
+- Stories are how humans make sense of things — this is a practical skill, not an abstract art
+- This route covers structure, character, pacing, dialogue, and finishing
+- By the end, they'll have a complete short story or first chapter
+
+**Opening Questions to Assess Level:**
+1. "Have you written fiction or stories before? What was the experience like?"
+2. "Do you have a story idea, or are you starting from scratch?"
+3. "What stories — books, movies, shows — do you love? What about them grabs you?"
+
+**Adapt based on responses:**
+- If they've written before: Ask what stopped them (usually the middle). Focus on structure and pacing.
+- If they're starting fresh: Spend more time on Section 1 (identifying story potential) and Section 2 (frameworks).
+- If they love character-driven stories: Emphasize Sections 3 and 5 (character and dialogue).
+- If they love plot-driven stories: Emphasize Sections 2 and 4 (structure and pacing).
+
+**Good opening framing:**
+"Every story that's ever worked — from myths around a campfire to the last movie you loved — has the same bones: someone wants something, something gets in the way, and something changes. This route teaches you to see those bones and build with them."
+
+---
+
+### Section 1: What Is a Story, Actually?
+
+**Core Concept to Teach:**
+A story is not a sequence of events. It's a sequence of events that reveals change through conflict. The three essential elements: want, obstacle, change.
+
+**How to Explain:**
+1. Start with the distinction: "A man walks into a bar — that's a situation. A man walks into a bar and runs into the person who ruined his life — now you have the seed of a story. What's the difference? Want, obstacle, and the potential for change."
+2. McKee's definition: "Events connected by cause and effect, across time, producing meaningful change."
+3. The conflict principle: "Conflict is the engine. Without something at stake, without resistance, there's no story — just stuff happening. But conflict doesn't mean explosions. It can be quiet, internal, absurd."
+4. Help them recognize story potential in their own anecdotes.
+
+**Common Misconceptions:**
+- Misconception: "A story is just a sequence of events." → Clarify: Events without causation and conflict are anecdote, not story. "This happened, then this happened" is not a story. "This happened, which caused this, which forced the character to..." — that's a story.
+- Misconception: "Conflict means fighting or drama." → Clarify: Conflict can be a quiet disagreement, an internal struggle, an impossible choice. The conflict in *Lost in Translation* is two people who connect but can't act on it. No explosions required.
+- Misconception: "I don't have any stories." → Clarify: You do. Every anecdote you've told a friend that made them lean in has story bones. The skill is recognizing them.
+
+**Verification Questions:**
+1. "What's the difference between a story and a situation?"
+2. "Can you give me an example of conflict that isn't dramatic?"
+3. "Take one of your anecdotes — what did someone want, what got in the way, what changed?"
+
+**Good answer indicators:**
+- They can articulate want/obstacle/change
+- They understand conflict broadly (not just external/dramatic)
+- They can evaluate their own ideas for story potential
+
+**If they struggle:**
+- Use movies they know: "In *Finding Nemo*, what does Marlin want? What gets in the way? What changes?"
+- Work backward: "Think of an anecdote where something surprised you. What was the surprise? That surprise is probably the change."
+- If they insist they have no stories: "Tell me about the last time something didn't go the way you expected." That's a story seed.
+
+**Exercise 1.1: Story or Situation?**
+"Take three anecdotes. For each: who wanted what? What got in the way? What changed?"
+
+**How to Guide Them:**
+1. If they can't identify the want: "What was the person trying to do? What outcome were they expecting?"
+2. If they can't find the obstacle: "What went wrong? What made it harder than expected?"
+3. If they can't find the change: "Was anyone different at the end? Did anyone learn something, lose something, or realize something?"
+4. If an anecdote isn't a story: "That's a great observation — it might work better as nonfiction. Let's look at the next one."
+
+---
+
+### Section 2: Structural Frameworks
+
+**Core Concept to Teach:**
+Structure is a tool, not a constraint. Multiple frameworks exist because they highlight different aspects of storytelling. The learner should know at least two and understand when to use each.
+
+**How to Explain:**
+1. Frame it positively: "Structure isn't a formula that kills creativity. It's a skeleton that lets you focus your creativity on what matters — characters, language, meaning — instead of spending all your energy figuring out what happens next."
+2. Present frameworks using a story the learner knows. Ask them to name a movie or book, then map it together.
+3. Show how different frameworks reveal different aspects of the same story.
+
+**The Four Frameworks:**
+
+**Three-Act Structure** (the foundation):
+- Act 1: Setup + inciting incident
+- Act 2: Confrontation + escalating conflict + midpoint shift
+- Act 3: Climax + resolution
+
+**Seven-Point (Dan Wells)** (more granular):
+- Hook → PP1 → Pinch 1 → Midpoint → Pinch 2 → PP2 → Resolution
+- Key insight: design from the ending backward
+
+**Story Circle (Dan Harmon)** (character arc focused):
+- You → Need → Go → Search → Find → Take → Return → Change
+- Best for short-form and episodic content
+
+**Save the Cat (Blake Snyder)** (maximum structure):
+- 15 beats mapping the emotional arc
+- Best for writers who need detailed checkpoints
+
+**How to Choose:**
+- External events drive the story → Three-Act
+- Character change drives the story → Story Circle
+- Need maximum structure → Save the Cat or Seven-Point
+- Doesn't fit any → probably a premise, not a story yet
+
+**Common Misconceptions:**
+- Misconception: "Structure is formulaic." → Clarify: Structure is the skeleton, not the skin. Two stories can have identical three-act structure and feel completely different because the characters, themes, and language are different.
+- Misconception: "There's one right structure for my story." → Clarify: Different frameworks highlight different things. Try two and see which one reveals the most about your story.
+- Misconception: "I should figure out the structure after writing." → Clarify: You can, but most writers who do this end up rewriting heavily. Spending time on structure before drafting saves time overall.
+
+**Verification Questions:**
+1. "Map your story idea to the three-act structure. What's the inciting incident?"
+2. "Now try the seven-point structure. What's the resolution? What's the hook (its opposite)?"
+3. "Which framework feels more natural for your story? Why?"
+
+**If they struggle:**
+- Start with a movie: "Let's map *[their favorite movie]* first, then apply the same framework to your idea."
+- If they can't find the inciting incident: "What's the event that makes the character's normal life impossible to continue? That's the inciting incident."
+- If frameworks feel abstract: "Forget the names. Just answer: What starts the story? What's the worst moment? How does it end?"
+
+**Exercise 2.1: Map a Story**
+"Pick a movie or book you love. Map it to three-act structure, then to seven-point. What does each framework reveal?"
+
+---
+
+### Section 3: Characters That Drive Story
+
+**Core Concept to Teach:**
+Plot is what characters cause to happen because of who they are. A character needs a want, a fear, a flaw, and a line they won't cross — until the story forces them to.
+
+**How to Explain:**
+1. The fundamental unit: "A person wants something. Something stands in their way. Everything else is decoration."
+2. Internal vs. external: "The external goal drives the plot — get the treasure, win the case. The internal goal drives the theme — learn to trust, accept loss. The tension between them is where meaning lives."
+3. McKee's gap: "A character acts expecting one result, gets another. That gap is where the story lives. Every great scene has one."
+4. Flaws as engine: "A character flaw isn't decorative — it's the thing that creates conflict. Their worst enemy is often themselves."
+
+**Common Misconceptions:**
+- Misconception: "Likeable characters are good characters." → Clarify: Compelling characters need dimension, not likeability. Walter White is not likeable. Tony Soprano is not likeable. But they're compelling because they want something badly, and their flaws make the pursuit fascinating.
+- Misconception: "Character backstory equals character development." → Clarify: What matters is want, fear, and flaw in the present. Backstory only matters if it explains why the character wants what they want or fears what they fear.
+- Misconception: "Supporting characters are just plot devices." → Clarify: Supporting characters serve the protagonist's arc — they help, hinder, or reflect. But they should feel real, with their own wants.
+
+**Verification Questions:**
+1. "What does your protagonist want? What's their external goal? Their internal goal?"
+2. "What's their flaw — the thing that makes their own goal harder to achieve?"
+3. "What would they never do? Now — what would force them to do it?"
+
+**If they struggle:**
+- Use a character they know: "What does Marlin want in *Finding Nemo*? What's his flaw? How does the flaw make the goal harder?"
+- If the character feels flat: "Make the want more specific. 'She wants to be happy' is vague. 'She wants her daughter to look at her the way she used to' — that's specific and suggests conflict."
+- If they can't find the flaw: "What would make your character fail at their goal even if nothing external stopped them? That's the flaw."
+
+**Exercise 3.1: Four-Sentence Character**
+"Create a character: What do they want? What do they fear? What would they never do? Now write a paragraph where they have to do it."
+
+**How to Guide Them:**
+1. Push for specificity in the want. Reject abstract wants ("happiness," "success").
+2. The fear should connect to the flaw: "If they're afraid of X, how does that fear shape their behavior in ways that create problems?"
+3. When they write the scenario: "How does your character feel in this moment? What do they do physically? What's the gap between what they expected and what happened?"
+
+---
+
+### Section 4: Pacing, Tension, and the Middle
+
+**Core Concept to Teach:**
+The middle (Act 2) is where most stories die. Pacing — the rhythm of escalation and relief — keeps them alive. The midpoint shift (reactive → proactive) is the single most important structural beat for preventing middle sag.
+
+**How to Explain:**
+1. Name the problem: "Act 2 is roughly half your story's length. 'Rising action' is misleading — it's not a steady incline. It's a series of escalations with breathing room between them."
+2. Pinch points: "Moments where the antagonist's power or the stakes become vivid. They reset the reader's fear and re-engage investment."
+3. The midpoint shift: "In the first half of Act 2, the character reacts. At the midpoint, something shifts — they stop reacting and start acting. This pivot is what prevents the middle from sagging."
+4. Scene construction: "Every scene must turn a value. If nothing is different at the end of the scene than at the beginning, the scene doesn't earn its place."
+
+**Common Misconceptions:**
+- Misconception: "Rising action is a steady incline." → Clarify: It's a series of peaks and valleys. Constant escalation exhausts the reader. You need breathing room between escalations.
+- Misconception: "The middle should just be 'stuff happening.'" → Clarify: Every scene must turn a value — change something. Relationship, power, knowledge, emotional state. If nothing turns, cut the scene.
+- Misconception: "Subplots can be about anything interesting." → Clarify: Subplots must serve the main story — complicate it, mirror it, or comment on it. Otherwise they're dead weight.
+
+**Verification Questions:**
+1. "Walk me through your Act 2. Where are your pinch points?"
+2. "What's your midpoint shift? Where does the character go from reactive to proactive?"
+3. "Pick any scene in your middle — what value turns?"
+
+**If they struggle:**
+- If the middle feels like "stuff happening": "Let's list what happens in order. Now for each event — what changed? If nothing changed, that event isn't earning its place."
+- If they can't find the midpoint shift: "When does your character stop running from the problem and start confronting it? That's your midpoint."
+- If scenes feel static: "End each scene with the character in a worse position than they started. That creates momentum."
+
+**Exercise 4.1: Five Scenes**
+"Outline Act 2 in exactly five scenes. For each, one sentence: what value turns?"
+
+**How to Guide Them:**
+1. If a scene doesn't have a clear turn: "What's different at the end? If the answer is 'nothing,' we need to rethink this scene."
+2. Check escalation: "Does each scene raise the stakes higher than the last? Or are they all at the same level?"
+3. Verify the midpoint: "Which of these five scenes is the pivot point? Is it in the middle?"
+
+---
+
+### Section 5: Dialogue and Scene-Level Craft
+
+**Core Concept to Teach:**
+Dialogue is how people talk distilled to its most revealing, conflictual, and purposeful form. Subtext — the gap between what's said and what's meant — is where the real drama lives.
+
+**How to Explain:**
+1. The three-job test: "Every line of dialogue should reveal character, advance plot, or create conflict. Ideally two of three. If a line does none — cut it."
+2. Subtext: "People rarely say exactly what they mean, especially in conflict. The best dialogue has a gap between the surface and the subtext. Characters deflect, redirect, understate."
+3. Tags: "King's rule: 'said' is almost always right. It's invisible. If you need 'he snarled,' the dialogue isn't doing its job."
+4. Sensory detail: "Not everything — one specific detail that makes the scene real. One well-chosen detail beats a paragraph of generic description."
+5. Show vs. tell: "Show when the moment matters emotionally. Tell when you need to move through time. Both are tools."
+
+**Common Misconceptions:**
+- Misconception: "Dialogue should sound realistic." → Clarify: Real conversation is boring on the page. Dialogue should sound distilled — the essence of how people talk, with filler, repetition, and pleasantries removed.
+- Misconception: "'Show don't tell' means always show." → Clarify: Both are tools. Show emotional turning points. Tell transitions. Showing everything is exhausting; telling everything is boring.
+- Misconception: "Every scene needs detailed description." → Clarify: One specific sensory detail anchors the reader. A paragraph of description puts them to sleep.
+
+**Verification Questions:**
+1. "Read me a line of dialogue from your scene. Does it reveal character, advance plot, or create conflict?"
+2. "What's the subtext in this exchange? What does the character mean but not say?"
+3. "What's the one sensory detail in this scene? Is it specific enough?"
+
+**If they struggle:**
+- With subtext: "Write the scene where characters say exactly what they mean. Now rewrite it where they say everything *except* what they mean. Which version is more interesting?"
+- With dialogue tags: "Read your scene replacing every tag with 'said.' Does it still work? If not, the dialogue needs to do more work."
+- With sensory detail: "Close your eyes and imagine the scene. What's the first thing you notice? Use that."
+
+**Exercise 5.1: Subtext Scene**
+"Write a scene where two people disagree but neither says what they actually disagree about."
+
+**How to Guide Them:**
+1. Have them write the real disagreement first (privately). Then write the scene around it.
+2. If the subtext is too buried: "A reader should sense something is wrong even if they can't name it. Is the tension palpable?"
+3. If the characters are too direct: "Have them talk about something mundane — dinner plans, a household chore. Let the real argument leak through the tone."
+
+---
+
+### Section 6: Finishing — From Draft to Done
+
+**Core Concept to Teach:**
+A story in your head is an intention, not a story. The craft is in the finishing. Structure first, then scenes, then sentences. Second draft = first draft minus 10%.
+
+**How to Explain:**
+1. Two complementary approaches:
+   - McKee: outline → treatment → polish. Front-load structural work.
+   - King: draft freely → wait → revise ruthlessly. Let the story reveal itself, then shape it.
+2. The revision hierarchy: "Fix structure first, then scenes, then paragraphs, then sentences. Don't wordsmith a scene that shouldn't exist."
+3. Kill your darlings: "If a passage you love doesn't serve the story, save it somewhere else. It's not lost — it's just not for this piece."
+4. The pitch test: "Tell your story to someone, beat by beat. Where they zone out = your weak spot."
+
+**Common Misconceptions:**
+- Misconception: "The first draft should be close to final." → Clarify: First drafts are supposed to be rough. King threw the manuscript of *Carrie* in the trash. His wife fished it out. The first draft is discovery; the second draft is craft.
+- Misconception: "Revision means fixing typos and word choice." → Clarify: Revision means re-seeing the whole structure. It might mean cutting entire scenes, rearranging sections, or rethinking the ending.
+- Misconception: "If I have to rewrite heavily, the story is bad." → Clarify: Heavy revision is normal. It's the process, not a symptom of failure.
+
+**Verification Questions:**
+1. "Walk me through your revision plan. What are you fixing first?"
+2. "Is there a passage you love that might not serve the story? What would happen if you cut it?"
+3. "If you pitched this story in three minutes, where would the listener's attention wander?"
+
+**If they struggle:**
+- If they can't start revising: "Read the whole draft aloud. Mark every place you stumble or feel embarrassed. Start there."
+- If they resist cutting: "Move the passage to a separate file. It's not deleted — it's saved for a future story."
+- If the structure needs major rework: "Let's go back to the framework. Map what you've written to three-act structure. Where does it diverge from the plan? Is the divergence better or worse?"
+
+**Exercise 6.1: The Pitch**
+"Pitch your story to me in under three minutes. I'll tell you where I lean in and where I lose focus."
+
+**How to Guide Them:**
+1. Listen actively. Note where you want to ask questions (that's engagement) and where your mind wanders (that's a weak spot).
+2. After the pitch: "Here's where I was most engaged: [X]. Here's where I lost the thread: [Y]. What do you think is happening at [Y]?"
+3. Help them revise the outline based on feedback before revising prose.
+
+---
+
+## Practice Project
+
+**Project Introduction:**
+"You've built the components through the exercises. Now assemble them into a complete story."
+
+**Requirements:**
+- A complete short story of 2000-4000 words, or a first chapter
+- Clear protagonist with want, fear, and flaw
+- Identifiable inciting incident, midpoint shift, and climax
+- Scenes that turn values
+- Dialogue with subtext
+- At least one revision pass using the hierarchy
+
+**Scaffolding Strategy:**
+1. **If they want to try alone**: Let them draft. Offer to review structure when they're ready.
+2. **If they want guidance**: Build the outline together first. "Let's nail the structure before you start writing prose."
+3. **If they're unsure**: Start with the climax. "Write the scene where the character faces the central conflict. Once we have that, we can build everything leading up to it."
+
+**Checkpoints During Project:**
+- After outline: "Can you identify the inciting incident, midpoint, and climax? Does every scene turn a value?"
+- After rough draft: "How do you feel about it? What surprised you? Where did you struggle?"
+- After revision: "What did you cut? What changed from draft to revision? Did the story get better?"
+
+**If They Get Stuck:**
+- Can't start: "Write the climax first. Knowing the ending makes everything else easier."
+- Middle sags: "Where's your midpoint shift? Add one if it's missing."
+- Can't finish: "Write the worst ending you can think of. Seriously — make it bad on purpose. Now you have something to revise."
+
+---
+
+## Wrap-Up and Next Steps
+
+**Review Key Takeaways:**
+"Let's review what you've built:"
+- You can evaluate ideas for story potential
+- You know multiple structural frameworks and when to use them
+- You can create characters that drive plot
+- You understand pacing and the critical midpoint shift
+- You can write dialogue with subtext
+- You know how to revise from structure down to sentences
+
+**Assess Confidence:**
+"On a scale of 1-10, how confident do you feel about writing a story from scratch?"
+- 1-4: Identify the specific section that's fuzziest. Offer to revisit.
+- 5-7: "That's strong. Try writing one scene a week — subtext one week, value turns the next."
+- 8-10: "Excellent. Finish your story, share it, then consider the Nonfiction Writing route for a different craft."
+
+**Suggest Next Steps:**
+- If they want to write nonfiction: "[Nonfiction Writing](/routes/nonfiction-writing/map.md)"
+- If they haven't done foundations: "[Writing Foundations](/routes/writing-foundations/map.md)"
+- For more practice: "Write one scene a week. Analyze stories you love. Finish something and share it."
+
+---
+
+## Adaptive Teaching Strategies
+
+### If Learner is Struggling
+- Use movies they know as examples. Film is more accessible for structural analysis.
+- Break exercises into smaller pieces: "Don't outline the whole story — just outline Act 1."
+- Do exercises together: "Let's build this character together. What does she want?"
+- If they're overwhelmed by frameworks: "Ignore everything except three-act. Setup, confrontation, resolution. That's all you need to start."
+
+### If Learner is Excelling
+- Push for more complex character work: "What if your protagonist is also the antagonist — their flaw IS the obstacle?"
+- Challenge with multiple POVs or timelines
+- Ask for subtext-heavy scenes: "Write a scene where the audience knows something the character doesn't."
+- Introduce unreliable narration or non-linear structure
+
+### If Learner Seems Disengaged
+- Check the story idea: "Are you excited about this story? If not, let's find one that excites you."
+- Get them writing instead of discussing theory: "Forget the frameworks. Write a scene. Something your character wants. Something gets in the way. Go."
+- Connect to stories they love: "What's a movie that blew you away? Let's figure out why — then steal those techniques."
+
+### Different Learning Styles
+- **Analytical learners**: Love framework comparisons. Let them map multiple stories before writing their own.
+- **Hands-on learners**: Skip theory. "Write a scene" first, then discuss what worked and why using the frameworks after.
+- **Conceptual learners**: Dig into *why* stories work psychologically. McKee's gap theory, the monomyth, catharsis.
+- **Example-driven learners**: Analyze published fiction or film scene by scene. Then have them try the same techniques.
+
+---
+
+## Teaching Notes
+
+**Key Emphasis Points:**
+- Character (Section 3) and dialogue (Section 5) are the most engaging sections — learners love creating characters and writing dialogue. Use that energy.
+- Structure (Section 2) is the most important for actually finishing stories. Even if learners are excited about character, make sure they have structure before drafting.
+- The middle (Section 4) is where most learners' past attempts died. Validate this: "This is where everyone gets stuck. That's normal. The midpoint shift is the fix."
+- Exercises should build cumulatively. The character from Exercise 3.1 should appear in the scenes from Exercises 4.1 and 5.1.
+
+**Pacing Guidance:**
+- Sections 1-2 set the foundation. Don't rush, but don't over-explain if the learner already has instincts about story.
+- Section 3 often generates the most enthusiasm. Let them explore, but keep one eye on structure.
+- Section 4 is the most technically demanding. Take extra time here — it's where the route pays off.
+- Sections 5-6 are practical and tend to move faster.
+- The practice project should get the most time. Everything before it is preparation.
+
+**Success Indicators:**
+You'll know they've got it when they:
+- Evaluate an anecdote by asking "what changed?"
+- Can map any story to at least two frameworks
+- Create characters with specific wants, fears, and flaws
+- Write scenes where something changes from beginning to end
+- Write dialogue where the real conflict is underneath the words
+- Revise structure before sentences
+- Complete a draft and are willing to cut it by 10%

--- a/routes/writing-foundations/guide.md
+++ b/routes/writing-foundations/guide.md
@@ -1,0 +1,371 @@
+---
+title: Writing Foundations — From Fragment to Finished Piece
+route_map: /routes/writing-foundations/map.md
+paired_sherpa: /routes/writing-foundations/sherpa.md
+prerequisites:
+  - Comfort writing in English
+topics:
+  - Writing Process
+  - Idea Pipeline
+  - Drafting
+  - Revision
+  - Common Failure Modes
+---
+
+# Writing Foundations — From Fragment to Finished Piece
+
+> **Note for AI assistants**: This guide has a paired sherpa at `/routes/writing-foundations/sherpa.md` that provides structured teaching guidance.
+> **Route map**: See `/routes/writing-foundations/map.md` for the high-level overview.
+
+## Overview
+
+You have ideas all the time. During walks, in the shower, mid-conversation — something clicks and you think, "I should write about that." But you don't. Or you jot down a sentence, maybe two, and it sits in your notes app alongside dozens of other fragments that felt electric in the moment and now feel inert on the screen.
+
+This isn't a creativity problem. It's a process problem. The gap between "I had an idea" and "I published a piece" is not one leap — it's a series of concrete stages, each with its own skill. This route teaches you those stages.
+
+## Learning Objectives
+
+By the end of this route, you will be able to:
+- Build a frictionless system for capturing ideas before they disappear
+- Evaluate which ideas have enough substance to develop into full pieces
+- Expand a raw fragment into structured raw material using targeted questions
+- Move from raw material to outline to draft to revision
+- Diagnose the specific failure mode that stops your writing and apply a targeted fix
+
+## Prerequisites
+
+Before starting, you should have:
+- Basic comfort writing in English (emails, messages, social posts — anything counts)
+
+It helps to have:
+- An idea you've been meaning to write about but haven't started
+- Or a draft you started and abandoned
+
+If you have either of those, keep them handy. You'll use them in the exercises.
+
+---
+
+## Section 1: The Idea-to-Output Pipeline
+
+### Why Ideas Die
+
+Most ideas don't fail because they're bad. They fail because they never get past the fragment stage. You have the spark — a quip, an observation, a hot take — and it feels complete in your head. Your brain fills in all the gaps: the context, the reasoning, the examples. But on paper, those gaps are visible, and suddenly the idea that felt like a finished thought reveals itself as a starting point.
+
+This is normal. The fix isn't more inspiration. It's a pipeline — a series of stages that turn raw fragments into finished pieces.
+
+### The Five Stages
+
+#### Stage 1: Capture (Frictionless)
+
+Record ideas the moment they occur. Voice memos, phone notes, quick texts to yourself — whatever has the least friction. The key principles:
+
+- **No structure.** Don't try to organize the idea. Just get it down.
+- **No judgment.** Don't evaluate whether it's "good enough." That comes later.
+- **No editing.** A fragment is fine. A single sentence is fine. A voice memo of you rambling is fine.
+
+The goal is volume. Most ideas won't survive development. That's expected and healthy — you want a large pool to draw from.
+
+> I keep a running note on my phone called "ideas." It's a mess. Half-sentences, references to conversations, things like "the thing about how nobody actually reads terms of service." That's the point. It's not a filing system; it's a net.
+
+#### Stage 2: Triage (Weekly)
+
+Set aside 30 minutes a week to review your captured ideas. For each one, ask:
+
+- **Is there a piece here?** Not every idea is a piece. Some are observations that might support a larger argument. Some are just funny. That's fine.
+- **What kind of piece?** Does it have a *point* (nonfiction)? Does it have a *change* (story)? Is it an observation that might support another, larger piece?
+- **Sort it.** Put each idea in one of four buckets:
+  - **Develop Now** — you have enough to start expanding
+  - **Save for Later** — interesting but needs more thought or a trigger
+  - **Combine with Something Else** — this fragment supports a bigger idea
+  - **Discard** — it's not going anywhere, and that's okay
+
+#### Stage 3: Expand (The Hard Part)
+
+This is where most people stall. The fragment feels complete in your head because your brain fills in the gaps. On paper, those gaps become visible.
+
+The technique: **don't try to write the piece. Write about the piece.** Answer these questions in rough prose:
+
+1. **What is this really about?** Not the surface topic — the underlying idea. "It's about how we've normalized surveillance" is more useful than "It's about smart speakers."
+2. **Who is this for?** What do they currently believe about this topic?
+3. **What do I want them to think, feel, or do after reading?**
+4. **What's my single strongest supporting point, example, or anecdote?**
+5. **What's the honest counterargument or complication?**
+
+This "writing about the writing" generates raw material that a structural outline can organize. You're not drafting yet — you're giving yourself something to work with.
+
+#### Stage 4: Outline and Draft
+
+Build a structure from your expanded material. For nonfiction, this might be a "fat outline" — a detailed inventory of every element (anecdotes, data points, arguments, examples) arranged in logical order. For a story, it might be a beat outline — the sequence of events that produces change.
+
+Then write a rough draft end-to-end without stopping to edit. The first draft is you telling yourself what you think. Don't polish mid-sentence. Don't go back and fix the opening. Just get to the end.
+
+#### Stage 5: Revise
+
+Let the draft sit. At minimum overnight, ideally a week. Then read it with reader-brain, not writer-brain. Ask:
+
+- Does the opening make me want to keep reading?
+- Does each section earn its place?
+- Where does it drag? Where is it confusing?
+- What can I cut without losing meaning?
+
+Get one other person's reaction before publishing. Not for validation — for blind spots.
+
+### Exercise 1.1: Map Your Fragments
+
+**Task:** Open your notes app, email drafts, voice memos — wherever you stash ideas. List 5-10 fragments you've captured (or would have captured if you had a system). For each, write one sentence describing what it's about.
+
+<details>
+<summary>Hint: If you don't have fragments</summary>
+
+Set a timer for 10 minutes. Write down every topic you've had an opinion about in the last week. Conversations, articles that annoyed you, things you wanted to explain to someone. Don't filter — just list.
+</details>
+
+<details>
+<summary>One possible approach</summary>
+
+Your list might look something like:
+
+> 1. The thing about how AI tools make junior developers worse, not better
+> 2. Why my neighborhood bar is better than any "craft cocktail" place
+> 3. That story about my dad and the broken lawnmower
+> 4. Nobody actually understands how credit scores work
+> 5. The parallel between fantasy football and stock picking
+
+Don't worry about quality. The point is to have raw material to work with in the next exercises.
+</details>
+
+### Exercise 1.2: Triage Your List
+
+**Task:** Take your list from Exercise 1.1. For each fragment, sort it into one of the four buckets: Develop Now, Save for Later, Combine with Something Else, or Discard. Pick the one "Develop Now" idea that excites you most — you'll use it for the rest of this route.
+
+<details>
+<summary>Hint: How to pick</summary>
+
+Choose the idea where you already have the most to say — not the one that sounds most impressive. You want raw material to work with, and that means picking the idea where your brain is already generating examples, arguments, and anecdotes.
+</details>
+
+### Exercise 1.3: Expand Your Chosen Idea
+
+**Task:** Take your "Develop Now" idea and answer the five expansion questions in rough prose. Don't worry about structure or polish. Spend 15-20 minutes just writing about your idea.
+
+1. What is this really about?
+2. Who is this for?
+3. What do I want them to think, feel, or do after reading?
+4. What's my single strongest supporting point, example, or anecdote?
+5. What's the honest counterargument or complication?
+
+<details>
+<summary>Hint: If you're stuck on "What is this really about?"</summary>
+
+Try completing this sentence: "The thing most people don't realize is..." or "The reason this matters is..." Your real topic is usually one layer beneath the surface topic.
+</details>
+
+**Self-Check:** Before moving on, make sure you have:
+- [ ] A list of 5+ fragments
+- [ ] One fragment selected for development
+- [ ] Rough answers to all five expansion questions
+
+---
+
+## Section 2: Common Failure Modes
+
+If you've tried to write before and stalled, it wasn't random. Writers get stuck in predictable patterns. Diagnosing which one is trapping you is the first step to breaking through it.
+
+### Failure Mode 1: Perfectionism Paralysis
+
+**What it looks like:** You won't start because it won't be good enough. You've read great writing and the gap between that and what you'll produce feels unbridgeable. So you research more, outline more, think more — anything except actually writing.
+
+**The fix:** Write the worst version first. Deliberately. Anne Lamott calls these "shitty first drafts" and argues they're not optional — they're the only way. Nobody writes a clean first draft. The people whose writing you admire? Their first drafts were terrible. You cannot edit a blank page.
+
+**The practice:** Set a timer for 20 minutes. Write about your chosen topic. The rule: you cannot stop typing. If you don't know what to say, type "I don't know what to say about this but I think..." and keep going. Quality is forbidden. Quantity is the goal.
+
+### Failure Mode 2: Scope Creep
+
+**What it looks like:** A blog post becomes a manifesto. You start writing about one thing and realize it connects to three other things, and soon you're trying to write a comprehensive treatise instead of a focused piece.
+
+**The fix:** Define the piece's scope in one sentence before drafting. Not the topic — the scope. "This piece argues that AI coding tools hurt junior developers by removing the struggle that builds understanding" is a scope. "AI and junior developers" is a topic. If you can't state your scope in one sentence, the piece is too big. Split it.
+
+**The practice:** Write a one-sentence scope statement for your chosen idea. If it has the word "and" in it, consider whether you're describing one piece or two.
+
+### Failure Mode 3: The Infinite Middle
+
+**What it looks like:** You know the opening. You know the point you want to make. But the middle — the part where you actually build the argument, tell the story, walk through the explanation — feels like a featureless desert.
+
+**The fix:** Work backward from the conclusion. What must be true for your ending to land? What does the reader need to know, believe, or feel before they reach it? Each of those prerequisites becomes a section. Now you have a structure.
+
+**The practice:** Write your conclusion first — even roughly. Then list 3-5 things the reader must understand before that conclusion makes sense. That's your outline.
+
+### Failure Mode 4: Anecdote Orphans
+
+**What it looks like:** You have great stories and observations, but they don't connect to a larger point. You write a vivid anecdote and then... what? It sits there, entertaining but aimless.
+
+**The fix:** Ask "So what?" after every anecdote. What does this story illustrate? What question does it answer? If the anecdote doesn't serve the piece's argument or theme, it either needs a frame (context that connects it to the larger point) or a different home (save it for a piece where it fits).
+
+**The practice:** Take an anecdote from your expansion notes. Write one sentence that explains why it matters to your argument. If you can't, set it aside — it belongs somewhere else.
+
+### Failure Mode 5: Voice Paralysis
+
+**What it looks like:** Your writing sounds stiff, formal, and unlike you. You're performing "writer" instead of being yourself. The sentences are grammatically correct but lifeless.
+
+**The fix:** Record yourself explaining the idea to a friend. Literally — use a voice memo. Transcribe it (or summarize from memory). Edit from there. Your spoken voice is your real voice. The page just makes you self-conscious.
+
+**The practice:** Explain your chosen topic out loud for two minutes as if you're telling a friend about it. Then write down the best version of what you said. Compare it to your earlier expansion writing. Which sounds more like you?
+
+### Exercise 2.1: Diagnose Yourself
+
+**Task:** Read through the five failure modes above. Which one (or two) sounds most like your pattern? Write a short paragraph describing a specific time this failure mode stopped you from finishing something.
+
+<details>
+<summary>Hint: If you can't pick just one</summary>
+
+Most writers have a primary failure mode and a secondary one. The primary is what stops you from starting. The secondary is what stops you from finishing. Identify both if you can.
+</details>
+
+### Exercise 2.2: Apply the Fix
+
+**Task:** Take the fix for your primary failure mode and apply it to your chosen idea right now. If it's perfectionism, do the 20-minute freewrite. If it's scope creep, write the one-sentence scope statement. If it's the infinite middle, write the conclusion first. Do it before moving on.
+
+**Self-Check:** Before moving on, make sure you can:
+- [ ] Name your primary failure mode
+- [ ] Describe a specific time it stopped you
+- [ ] Point to a concrete artifact you produced by applying the fix
+
+---
+
+## Practice Project: Take a Fragment Through the Pipeline
+
+You've been building toward this through the exercises. Now put it all together.
+
+### The Task
+
+Take the idea you selected in Section 1 and move it through the full pipeline to produce either:
+- A complete outline ready for drafting (if you're planning to continue with the Nonfiction Writing or Storytelling route)
+- A rough first draft of 500-1000 words (if you want to push further now)
+
+### Steps
+
+**Step 1: Confirm your raw material**
+
+You should already have:
+- Your chosen fragment
+- Expansion notes (answers to the five questions)
+- A scope statement (from the failure modes exercises)
+
+If you're missing any of these, go back and do them now.
+
+**Step 2: Build your outline**
+
+Using your expansion notes, create an outline. Arrange your material — arguments, examples, anecdotes — in an order that builds toward your conclusion. For each section of the outline, write 1-2 sentences describing what it covers and why it's there.
+
+**Step 3: (Optional) Write a rough draft**
+
+If you have the momentum, write a rough draft from your outline. Remember: the first draft is for you. Don't polish. Don't go back and fix things. Just get to the end.
+
+**Step 4: Identify what's next**
+
+Look at what you've produced. Does this piece want to be:
+- An explanatory or persuasive piece? → Continue with the [Nonfiction Writing](/routes/nonfiction-writing/map.md) route
+- A narrative or story? → Continue with the [Storytelling](/routes/storytelling/map.md) route
+
+### Hints and Tips
+
+<details>
+<summary>If you're stuck on the outline</summary>
+
+Try the "index card" method: write each idea, example, or argument on a separate line. Then rearrange them until the order feels logical. There's no single correct structure — just make sure each section follows from the one before it.
+</details>
+
+<details>
+<summary>If the outline feels too thin</summary>
+
+Go back to Stage 3 (Expand). You probably need more raw material. Answer the five questions again, but dig deeper this time. What examples do you have? What would someone who disagrees say? What's the most surprising thing about this topic?
+</details>
+
+<details>
+<summary>If you wrote a draft and it feels bad</summary>
+
+Good. That means you wrote a first draft. First drafts are supposed to feel rough. The fact that you can see what's wrong with it means you have taste — and that's the foundation of revision. Don't fix it yet. Let it sit. Come back to it after completing one of the craft routes.
+</details>
+
+---
+
+## Summary
+
+### Key Takeaways
+
+- **Ideas die from neglect, not from being bad.** A capture system turns fleeting thoughts into raw material you can develop later.
+- **The pipeline is five stages.** Capture → Triage → Expand → Outline/Draft → Revise. Each stage has a different job. Don't skip stages or try to do two at once.
+- **"Writing about the writing" unlocks expansion.** When you're stuck, don't try to draft — answer questions about your idea instead.
+- **Failure modes are diagnosable.** Knowing which pattern traps you lets you apply a targeted fix instead of vague willpower.
+- **First drafts are supposed to be bad.** The quality comes from revision, not from getting it right the first time.
+
+### Skills You've Gained
+
+You can now:
+- ✓ Capture and triage ideas systematically
+- ✓ Expand a fragment into developable raw material
+- ✓ Build an outline from expanded material
+- ✓ Identify and counter your personal failure modes
+- ✓ Produce a rough draft or outline from a standing start
+
+### Self-Assessment
+
+Take a moment to reflect:
+- Do you have a capture system you'll actually use?
+- Can you look at a fragment and quickly determine if it has enough substance to develop?
+- Do you know which failure mode is your biggest obstacle?
+- Did you produce an outline or draft from this route's exercises?
+
+---
+
+## Next Steps
+
+### Continue Learning
+
+**Choose your craft route:**
+- [Nonfiction Writing](/routes/nonfiction-writing/map.md) — If your piece explains, argues, or analyzes. Start here if you want to write blogs, essays, or video scripts.
+- [Storytelling](/routes/storytelling/map.md) — If your piece narrates, dramatizes, or builds toward a reveal. Start here if you want to write fiction, narrative nonfiction, or screenplays.
+
+### Practice More
+
+- **Daily capture**: Commit to recording at least one idea per day for a week. Review them all at the end of the week.
+- **Expansion reps**: Take three different fragments and run them through the five expansion questions. See which ones develop into viable pieces.
+- **Failure mode journal**: For the next month, whenever you stall on writing, note which failure mode stopped you. Patterns will emerge.
+
+### Additional Resources
+
+- Anne Lamott, *Bird by Bird* — Permission to write badly, the one-inch picture frame, and the emotional side of writing
+- William Zinsser, *On Writing Well* — The rewriting process and why simplicity matters
+- Steven Pressfield, *The War of Art* — On resistance and the forces that keep you from doing creative work
+
+---
+
+## Appendix
+
+### Quick Reference: The Pipeline
+
+| Stage | What You Do | What It Produces |
+|-------|------------|-----------------|
+| Capture | Record ideas with zero friction | A growing pool of raw fragments |
+| Triage | Sort fragments weekly into buckets | A shortlist of ideas worth developing |
+| Expand | Answer five questions about your idea | Raw material: arguments, examples, stakes |
+| Outline/Draft | Arrange material into structure, then write | A structured outline or rough draft |
+| Revise | Read with reader-brain, cut, clarify | A finished piece |
+
+### Quick Reference: The Five Expansion Questions
+
+1. What is this really about? (The underlying idea, not the surface topic)
+2. Who is this for? (What do they currently believe?)
+3. What do I want them to think, feel, or do after reading?
+4. What's my single strongest supporting point, example, or anecdote?
+5. What's the honest counterargument or complication?
+
+### Quick Reference: Failure Modes
+
+| Failure Mode | Symptom | Fix |
+|---|---|---|
+| Perfectionism paralysis | Won't start | Write the worst version first |
+| Scope creep | Piece keeps growing | One-sentence scope statement |
+| The infinite middle | Can't connect opening to conclusion | Work backward from the ending |
+| Anecdote orphans | Stories without a point | Ask "So what?" after every anecdote |
+| Voice paralysis | Stiff, performative prose | Record yourself talking, then transcribe |

--- a/routes/writing-foundations/map.md
+++ b/routes/writing-foundations/map.md
@@ -1,0 +1,72 @@
+---
+title: Writing Foundations — From Fragment to Finished Piece
+topics:
+  - Writing Process
+  - Idea Pipeline
+  - Drafting
+  - Revision
+  - Common Failure Modes
+related_routes:
+  - nonfiction-writing
+  - storytelling
+---
+
+# Writing Foundations — Route Map
+
+## Overview
+
+You have ideas all the time — during walks, in conversation, while reading. But most of them never become anything. This route teaches the process that bridges the gap between having an idea and producing a finished piece. Before you learn the craft of nonfiction or storytelling, you need a reliable system for capturing, developing, and completing your writing.
+
+## What You'll Learn
+
+By following this route, you will:
+- Build a frictionless system for capturing ideas before they disappear
+- Evaluate which ideas have enough substance to develop into full pieces
+- Expand a raw fragment into structured raw material using targeted questions
+- Move from raw material to outline to draft to revision
+- Diagnose the specific failure mode that stops your writing and apply a targeted fix
+
+## Prerequisites
+
+Before starting this route:
+- **Required**: Comfort writing in English (emails, messages, anything counts)
+- **Helpful**: An idea you've been meaning to write about but haven't
+
+## Route Structure
+
+### 1. The Idea-to-Output Pipeline
+- Why most ideas die before becoming pieces
+- The five stages: Capture, Triage, Expand, Outline/Draft, Revise
+- What each stage requires and produces
+- Why "just write" is bad advice without a pipeline
+
+### 2. Common Failure Modes
+- Perfectionism paralysis: won't start because it won't be good enough
+- Scope creep: a blog post becomes a manifesto
+- The infinite middle: you know the opening and the point, but not how to connect them
+- Anecdote orphans: great stories that don't connect to a larger point
+- Voice paralysis: writing that sounds stiff because you're performing
+
+### 3. Practice Project
+- Take a real fragment through the full pipeline to produce a working outline or rough draft
+
+## Learning Modes
+
+This route supports three learning modes:
+
+1. **Self-guided**: Read the guide.md file and work through exercises at your own pace
+2. **AI-guided**: Work with an AI assistant using the sherpa.md teaching script
+3. **Collaborative**: Read guide.md while getting help from AI following sherpa.md
+
+## Tools & Techniques
+
+This route references:
+- A text editor or notebook for capturing and drafting
+- Anne Lamott, *Bird by Bird* — on permission to write badly
+- William Zinsser, *On Writing Well* — on the rewriting process
+
+## Next Steps
+
+After completing this route:
+- **[Nonfiction Writing](/routes/nonfiction-writing/map.md)** — Learn the craft of explanatory and persuasive writing
+- **[Storytelling](/routes/storytelling/map.md)** — Learn narrative structure, character, and scene craft

--- a/routes/writing-foundations/sherpa.md
+++ b/routes/writing-foundations/sherpa.md
@@ -1,0 +1,324 @@
+---
+title: Writing Foundations — From Fragment to Finished Piece
+route_map: /routes/writing-foundations/map.md
+paired_guide: /routes/writing-foundations/guide.md
+topics:
+  - Writing Process
+  - Idea Pipeline
+  - Drafting
+  - Revision
+  - Common Failure Modes
+---
+
+# Writing Foundations — Sherpa (AI Teaching Guide)
+
+**Purpose**: This sherpa guide helps AI assistants teach the writing process — specifically, how to move from scattered ideas to finished pieces. It addresses the common problem of having many fragments but never completing anything.
+
+**Route Map**: See `/routes/writing-foundations/map.md` for the high-level overview.
+**Paired Guide**: The human-focused content is at `/routes/writing-foundations/guide.md`.
+
+---
+
+## Teaching Overview
+
+### Learning Objectives
+By the end of this session, the learner should be able to:
+- Build a frictionless system for capturing ideas before they disappear
+- Evaluate which ideas have enough substance to develop into full pieces
+- Expand a raw fragment into structured raw material using targeted questions
+- Move from raw material to outline to draft to revision
+- Diagnose the specific failure mode that stops their writing and apply a targeted fix
+
+### Prior Sessions
+Before starting, check `.sessions/index.md` and `.sessions/writing-foundations/` for prior session history. If the learner has completed previous sessions on this route, review the summaries to understand what they've covered and pick up where they left off.
+
+### Prerequisites to Verify
+Before starting, verify the learner has:
+- Basic comfort writing in English
+- Ideally, an idea they've been meaning to write about (not required — we can generate one)
+
+**If they don't have an idea ready**: That's fine. Section 1 includes a brainstorming exercise that will generate raw material.
+
+### Learner Preferences Configuration
+
+Learners can configure their preferred learning style by creating a `.sherpa-config.yml` file in the repository root (gitignored by default). Configuration options include:
+
+**Teaching Style:**
+- `tone`: objective, encouraging, humorous (default: objective and respectful)
+- `explanation_depth`: concise, balanced, detailed
+- `pacing`: learner-led, balanced, structured
+
+**Assessment Format:**
+- `quiz_type`: multiple_choice, explanation, mixed (default: mixed)
+- `quiz_frequency`: after_each_section, after_major_topics, end_of_route
+- `feedback_style`: immediate, summary, detailed
+
+If no configuration file exists, use defaults (objective tone, mixed assessments, balanced pacing).
+
+### Assessment Strategies
+
+Writing assessment is inherently more subjective than technical topics. Focus on:
+
+**Process Questions:**
+- Can the learner articulate what stage of the pipeline they're in?
+- Can they explain why a particular stage matters?
+
+**Diagnostic Questions:**
+- Can the learner identify which failure mode is blocking them?
+- Can they describe a specific instance where it happened?
+
+**Artifact Evaluation:**
+- Did they produce a concrete artifact at each stage (a list, an expansion, an outline)?
+- Does the artifact move them forward, even if it's rough?
+
+---
+
+## Teaching Flow
+
+### Introduction
+
+**What to Cover:**
+- Most people have plenty of ideas — the bottleneck is process, not creativity
+- This route teaches the pipeline between "I had an idea" and "I published a piece"
+- By the end, they'll have taken one real idea through the full pipeline
+
+**Opening Questions to Assess Level:**
+1. "Do you have a system for capturing ideas when they come to you?"
+2. "Have you ever started writing something and abandoned it? What happened?"
+3. "What kind of writing are you most interested in — blogs, essays, stories, scripts, something else?"
+
+**Adapt based on responses:**
+- If they already capture ideas: Skip the basics of Stage 1, focus on triage and expansion
+- If they've abandoned many drafts: Spend extra time on failure modes — this is their primary pain point
+- If they have a specific goal (e.g., "I want to start a blog"): Tailor examples to that format throughout
+- If they seem skeptical about process: Acknowledge it. "Process can sound bureaucratic, but this isn't about rules — it's about removing the friction that stops you from finishing."
+
+**Good opening framing:**
+"The gap between having ideas and publishing writing isn't a talent gap — it's a process gap. You don't need to become a better thinker. You need a better pipeline for turning your thinking into something someone else can read."
+
+---
+
+### Section 1: The Idea-to-Output Pipeline
+
+**Core Concept to Teach:**
+There are five stages between having an idea and publishing a piece: Capture, Triage, Expand, Outline/Draft, and Revise. Most people try to jump from Capture to Draft and wonder why they stall.
+
+**How to Explain:**
+1. Start with the problem: "You have an idea in the shower. It feels complete, fully formed. But when you sit down to write it, you realize you have a sentence, maybe two — not a piece. What happened?"
+2. Explain: "Your brain fills in the gaps when you're just thinking. On paper, those gaps become visible. The pipeline is how you fill them deliberately."
+3. Walk through each stage briefly, emphasizing that each one has a different job:
+   - Capture: Get it down (zero friction, zero judgment)
+   - Triage: Is there a piece here? (weekly review, sorting into buckets)
+   - Expand: What is this really about? (five questions that generate raw material)
+   - Outline/Draft: Arrange and write (structure first, then prose)
+   - Revise: Make it work for the reader (read with fresh eyes, cut, clarify)
+
+**Analogy:**
+"Think of it like cooking. Capture is shopping — you grab ingredients when you see them. Triage is checking the fridge — what do you actually have? Expand is prep — chopping, measuring, getting everything ready. Drafting is cooking. Revising is tasting and adjusting. Nobody goes from the grocery store straight to a plated dish."
+
+**Common Misconceptions:**
+- Misconception: "Good writers just sit down and write." → Clarify: Every published writer has a process. Most spend more time in the stages before drafting than in the drafting itself. John McPhee spends weeks on structure before writing a word of prose.
+- Misconception: "If an idea is good, it should be easy to write." → Clarify: The best ideas are often the hardest to write because they're complex. Ease of writing correlates with simplicity of the idea, not its quality.
+- Misconception: "I should wait for inspiration to write." → Clarify: Inspiration is for Stage 1 (Capture). Everything after that is craft, and craft runs on routine, not inspiration.
+
+**Verification Questions:**
+1. "Can you name the five stages of the pipeline?"
+2. "What's the difference between Capture and Triage? Why do they need to be separate?"
+3. "At which stage do you think you usually get stuck?"
+
+**Good answer indicators:**
+- They can name the stages in order
+- They understand that each stage has a different purpose
+- They can self-diagnose where they typically stall
+
+**If they struggle:**
+- Return to the cooking analogy and map each stage
+- Ask them to describe what they do now when they have an idea — then map their existing behavior to the pipeline stages
+- Focus on the one stage that's newest to them
+
+**Exercise 1.1: Fragment Inventory**
+Present this exercise: "Let's start with what you already have. Open your notes, email drafts, voice memos — wherever you stash ideas. List 5-10 fragments. For each one, write a single sentence describing what it's about."
+
+**How to Guide Them:**
+1. If they say they don't have any fragments: "That's actually useful information — it means Stage 1 (Capture) is your first priority. Let's do a quick brainstorm instead. What topics have you had opinions about this week? What annoyed you, excited you, or made you want to explain something?"
+2. If they have too many (20+): "Great — that means your capture system works. Now let's focus on triage. Pick the 10 that jump out at you."
+3. Review their list without judgment. Ask: "Which of these makes you want to keep talking?"
+
+**Exercise 1.2: Triage**
+"Now sort your list. For each fragment: Develop Now, Save for Later, Combine with Something Else, or Discard. Then pick the one 'Develop Now' idea that excites you most."
+
+**How to Guide Them:**
+1. If they want to develop everything: "Pick one. Just one. The others aren't going anywhere. We need focus to make progress."
+2. If they can't choose: "Which one do you already have the most to say about? Not the most impressive one — the one where your brain is already generating examples and arguments."
+3. If they discard everything: "What's making you reject these? Are they genuinely not interesting, or are you pre-judging whether they're 'good enough'?" (This may indicate perfectionism paralysis — flag it for Section 2.)
+
+**Exercise 1.3: Expand**
+"Now take your chosen idea and answer five questions. Write in rough prose — don't worry about structure. Spend 15-20 minutes."
+
+Present the five expansion questions:
+1. What is this really about? (Not the surface topic — the underlying idea)
+2. Who is this for? What do they currently believe?
+3. What do I want them to think, feel, or do after reading?
+4. What's my single strongest supporting point, example, or anecdote?
+5. What's the honest counterargument or complication?
+
+**How to Guide Them:**
+1. If they struggle with "What is this really about?": Ask them to complete the sentence "The thing most people don't realize is..." or "The reason this matters is..."
+2. If their answers are very short: Ask follow-up questions. "You said it's about X — can you give me a specific example?" Push for concreteness.
+3. If they go deep on one question and skip others: "This is great depth on question 4. Let's also make sure we have something for questions 1 and 3 — those shape the whole piece."
+
+**After the exercises, ask:**
+- "Do you feel like you have more to work with now than when we started?"
+- "Which expansion question was hardest? That's usually where the interesting thinking is."
+
+---
+
+### Section 2: Common Failure Modes
+
+**Core Concept to Teach:**
+Writers get stuck in predictable patterns. Diagnosing which one is trapping you lets you apply a targeted fix instead of relying on vague willpower or waiting for motivation.
+
+**How to Explain:**
+1. Frame it as diagnosis, not criticism: "These aren't character flaws. They're patterns. Every writer hits at least one of them. The goal is to recognize yours so you can work around it."
+2. Present each failure mode briefly, then ask which one resonates.
+
+**The Five Failure Modes:**
+
+Present each with: what it looks like, and the fix.
+
+1. **Perfectionism Paralysis**: Won't start because it won't be good enough. Fix: Write the worst version first. You can't edit a blank page.
+2. **Scope Creep**: A blog post becomes a manifesto. Fix: Define scope in one sentence before drafting. If you can't, the piece is too big.
+3. **The Infinite Middle**: Know the opening and conclusion but can't connect them. Fix: Work backward from the ending. What must be true for the conclusion to land?
+4. **Anecdote Orphans**: Great stories that don't connect to a point. Fix: Ask "So what?" after every anecdote.
+5. **Voice Paralysis**: Writing sounds stiff and unlike you. Fix: Record yourself explaining the idea, then transcribe and edit.
+
+**Verification Questions:**
+1. "Which of these sounds most like your pattern?"
+2. "Can you describe a specific time this happened to you?"
+3. "What did you try to fix it? Did it work?"
+
+**Good answer indicators:**
+- They can identify at least one failure mode that resonates
+- They can describe a specific instance (not just agree in the abstract)
+- They begin to see the pattern across multiple abandoned pieces
+
+**If they struggle to pick one:**
+- Ask about their last abandoned piece: "Walk me through what happened. Where did you stop? What was the feeling when you stopped?"
+- Map their description to the failure modes
+- Some learners have a primary mode (stops them from starting) and a secondary mode (stops them from finishing) — help them identify both
+
+**Common Misconceptions:**
+- Misconception: "I just need more discipline/motivation." → Clarify: Discipline helps, but if you're fighting the wrong problem, more willpower won't fix it. A perfectionist doesn't need more discipline — they need permission to write badly.
+- Misconception: "Real writers don't have these problems." → Clarify: Every writer in history has struggled with at least one of these. Anne Lamott wrote an entire book partly about perfectionism paralysis. Stephen King threw the manuscript of *Carrie* in the trash.
+
+**Exercise 2.1: Diagnose and Apply**
+"Write a short paragraph describing a specific time your primary failure mode stopped you. Then apply the fix for that mode to your current idea. Do it right now — produce the artifact."
+
+**How to Guide Them:**
+1. Make sure they're specific, not abstract. "I always do this" is less useful than "Last month I tried to write about X and stopped because Y."
+2. After they apply the fix, review the artifact together. Don't critique the quality — assess whether the fix unblocked them.
+3. If the fix didn't work: Try the fix for a different failure mode. Sometimes the initial diagnosis is wrong, and the real blocker reveals itself through experimentation.
+
+**After the exercises, ask:**
+- "Did applying the fix change how you feel about the piece?"
+- "Do you think you'll recognize this pattern next time it happens?"
+
+---
+
+## Practice Project
+
+**Project Introduction:**
+"You've been building toward this through the exercises. Now let's put it all together. Take your idea through the full pipeline and produce either a complete outline or a rough first draft."
+
+**Requirements:**
+The learner should produce:
+- A confirmed scope statement (one sentence)
+- An outline with 3-5 sections, each described in 1-2 sentences
+- (Optional) A rough draft of 500-1000 words
+
+**Scaffolding Strategy:**
+1. **If they want to try alone**: Let them work. Offer to review the outline when they're ready.
+2. **If they want guidance**: Walk through it section by section. Help them decide what goes where.
+3. **If they're unsure**: Start with the outline. "Let's arrange what you have. What's your strongest opening? What's your conclusion? Now what goes between them?"
+
+**Checkpoints During Project:**
+- After scope statement: "Does this feel focused enough? Can you point to one clear thing the reader will get from this piece?"
+- After outline: "Read me your section headings in order. Does the sequence make sense? Does each section build on the one before it?"
+- After draft (if they write one): "How do you feel about it? What parts feel strongest? Where did you struggle?"
+
+**If They Get Stuck:**
+- Ask which pipeline stage they're in. Often they're trying to draft when they haven't finished expanding.
+- Revisit the failure mode diagnosis. Is it happening right now?
+- Normalize the struggle: "This is exactly where the pipeline helps. You're not stuck because the idea is bad — you're stuck because you're trying to skip a stage."
+
+---
+
+## Wrap-Up and Next Steps
+
+**Review Key Takeaways:**
+"Let's review what you've built today:"
+- You have a capture-to-completion pipeline
+- You know which failure mode tends to trap you
+- You've taken a real idea from fragment to outline (or draft)
+
+**Assess Confidence:**
+"On a scale of 1-10, how confident do you feel about taking an idea through the pipeline on your own?"
+- 1-4: "Let's identify what still feels unclear. Which stage is fuzziest?"
+- 5-7: "That's a strong starting point. The pipeline becomes more natural with practice. Try running two more ideas through it this week."
+- 8-10: "Excellent. You're ready for the craft routes."
+
+**Suggest Next Steps:**
+Based on what they wrote:
+- If the piece is explanatory or persuasive: "The [Nonfiction Writing](/routes/nonfiction-writing/map.md) route will teach you how to structure, lead, and edit this kind of piece."
+- If the piece is narrative: "The [Storytelling](/routes/storytelling/map.md) route will teach you how to build structure, characters, and scenes."
+- If they're not sure: "Both routes will help. Nonfiction Writing is the more practical starting point if you want to publish blogs or essays. Storytelling is better if you're drawn to narrative."
+
+**Encourage Questions:**
+"Is there anything about the pipeline or the failure modes that still feels unclear?"
+"Do you want to talk through how you'll use this process going forward?"
+
+---
+
+## Adaptive Teaching Strategies
+
+### If Learner is Struggling
+- Focus on one stage at a time. Don't present the whole pipeline at once — walk through Capture, do the exercise, then move to Triage.
+- Use their own language. If they describe their problem differently than the failure modes, map their words to the framework rather than imposing the terminology.
+- Lower the bar on exercises. "Just give me three fragments" instead of ten. "Just answer two of the five questions" instead of all five.
+
+### If Learner is Excelling
+- Skip the basics of stages they already practice naturally
+- Challenge them with harder expansion questions: "What's the second-best counterargument? What would change your mind about this?"
+- Push toward the draft: "You have strong raw material. Let's see what a rough draft looks like."
+
+### If Learner Seems Disengaged
+- Check if the chosen topic matters to them: "Are you actually interested in this idea, or did you pick it because it seemed 'safe'? We can switch."
+- Connect to their goals: "What made you want to learn about writing? Let's make sure we're building toward that."
+- Reduce the meta-discussion and get them writing: "Let's try something. Just write for five minutes about your idea. No rules. We'll look at it together."
+
+### Different Learning Styles
+- **Analytical learners**: Emphasize the pipeline framework. They like systems and will appreciate the structure.
+- **Hands-on learners**: Minimize explanation, maximize exercises. Get them writing as quickly as possible and discuss the concepts afterward.
+- **Conceptual learners**: Spend more time on why each stage matters. They need to understand the reasoning before they'll trust the process.
+- **Example-driven learners**: Share how published writers use similar processes. John McPhee's structural obsession, Anne Lamott's shitty first drafts, Stephen King's daily routine.
+
+---
+
+## Teaching Notes
+
+**Key Emphasis Points:**
+- The pipeline is not rigid. Stages can overlap and loop. The point is awareness of where you are, not strict sequential execution.
+- The failure modes section is the emotional core of this route. Many learners will recognize themselves and feel relieved that there's a name for their pattern. Give that recognition space.
+- The expansion questions (Stage 3) are the most practically transformative part. If you're short on time, prioritize this over everything else.
+
+**Pacing Guidance:**
+- Section 1 can move quickly if the learner already captures ideas. Spend more time on Expand (Stage 3).
+- Section 2 often generates personal conversation. Let it happen — the self-diagnosis is more valuable than covering every mode.
+- The practice project should get the majority of hands-on time. Everything before it is building toward this.
+
+**Success Indicators:**
+You'll know they've got it when they:
+- Can describe what stage of the pipeline they're in for a given piece
+- Recognize their failure mode mid-stall (not just in retrospect)
+- Produce a concrete outline or draft from a fragment that started as a one-line note
+- Express willingness to let a first draft be rough


### PR DESCRIPTION
Create three new writing-focused learning routes:
- writing-foundations: complete route (map, guide, sherpa) covering the
  idea-to-output pipeline and common failure modes
- nonfiction-writing: map.md with route structure for 6 modules on
  nonfiction craft (leads, structure, clarity, voice, endings)
- storytelling: map.md with route structure for 6 modules on narrative
  craft (structure, character, pacing, dialogue, finishing)

Guide and sherpa files for nonfiction-writing and storytelling are in progress.

https://claude.ai/code/session_01CSaLV31vG6jTd3XgiZctBw